### PR TITLE
Fix validation of text for an XMLStreamWriter.

### DIFF
--- a/src/main/java/com/ctc/wstx/sw/BaseStreamWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/BaseStreamWriter.java
@@ -382,7 +382,7 @@ public abstract class BaseStreamWriter
                 /* Last arg is false, since we do not know if more text
                  * may be added with additional calls
                  */
-                mValidator.validateText(text, start, len, false);
+                mValidator.validateText(text, start, start + len, false);
             }
         }
 
@@ -1064,7 +1064,7 @@ public abstract class BaseStreamWriter
             /* Last arg is false, since we do not know if more text
              * may be added with additional calls
              */
-            mValidator.validateText(cbuf, start, len, false);
+            mValidator.validateText(cbuf, start, start + len, false);
         }
         int ix;
         try {

--- a/src/test/java/wstxtest/msv/TestW3CSchemaTypes.java
+++ b/src/test/java/wstxtest/msv/TestW3CSchemaTypes.java
@@ -7,6 +7,8 @@ import org.codehaus.stax2.validation.*;
 
 import wstxtest.vstream.BaseValidationTest;
 
+import java.io.StringWriter;
+
 /**
  * Simple testing of W3C Schema datatypes.
  * Added to test [WSTX-210].
@@ -60,6 +62,24 @@ public class TestW3CSchemaTypes
         XMLValidationSchema schema = parseW3CSchema(SCHEMA_FLOAT);
         verifyFailure("<price>abc</price>", schema, "invalid 'float' value",
                       "does not satisfy the \"float\" type");
+    }
+
+    // // // Writing
+
+    public void testValdiationWhenWritingCharactersFromArray() throws Exception
+    {
+        XMLValidationSchema schema = parseW3CSchema(SCHEMA_INT);
+
+        XMLOutputFactory2 f = getOutputFactory();
+        XMLStreamWriter2 sw = (XMLStreamWriter2)f.createXMLStreamWriter(new StringWriter());
+        sw.validateAgainst(schema);
+
+        String xml = "<price>129</price>";
+
+        sw.writeStartElement("price");
+        sw.writeCharacters(xml.toCharArray(), xml.indexOf("1"), 3);
+        sw.writeEndElement();
+        sw.flush();
     }
 
     /*


### PR DESCRIPTION
In our project we use woodstox to validate the stream written to an XMLStreamWriter. 

At first we used the `writeCharacters(char[] text, int start, int len)` method for writing to the XMLStreamWriter. Then validation failed with the message: *ParseError at [row,col]:[5,30] Message: Unknown reason*. When using `writeCharacters(String text)` everything worked fine.

The changes in this pull request should fix this issue.