### PR TITLE
Implement a flag to allow XML 1.1 escaped characters in XML content

### DIFF
--- a/src/main/java/com/ctc/wstx/api/ReaderConfig.java
+++ b/src/main/java/com/ctc/wstx/api/ReaderConfig.java
@@ -102,6 +102,7 @@ public final class ReaderConfig
     final static int PROP_LAZY_PARSING = 44;
     final static int PROP_SUPPORT_DTDPP = 45;
     final static int PROP_TREAT_CHAR_REFS_AS_ENTS = 46;
+    final static int PROP_XML10_ALLOW_ALL_ESCAPED_CHARS = 47;
 
     // Object type properties:
 
@@ -301,6 +302,8 @@ public final class ReaderConfig
                         */
         sProperties.put(WstxInputProperties.P_TREAT_CHAR_REFS_AS_ENTS,
                 PROP_TREAT_CHAR_REFS_AS_ENTS);
+        sProperties.put(WstxInputProperties.P_XML10_ALLOW_ALL_ESCAPED_CHARS,
+                PROP_XML10_ALLOW_ALL_ESCAPED_CHARS);
         sProperties.put(WstxInputProperties.P_NORMALIZE_LFS, PROP_NORMALIZE_LFS);
         
 
@@ -700,6 +703,10 @@ public final class ReaderConfig
         return _hasConfigFlag(CFG_TREAT_CHAR_REFS_AS_ENTS);
     }
 
+    public boolean willXml10AllowAllEscapedChars() {
+        return _hasConfigFlag(CFG_XML10_ALLOW_ALL_ESCAPED_CHARS);
+    }
+
     public int getInputBufferLength() { return mInputBufferLen; }
 
     public int getShortestReportedTextSegment() { return mMinTextSegmentLen; }
@@ -892,7 +899,11 @@ public final class ReaderConfig
     public void doTreatCharRefsAsEnts(final boolean state) {
         setConfigFlag(CFG_TREAT_CHAR_REFS_AS_ENTS, state);
     }
-    
+
+    public void doXml10AllowAllEscapedChars(final boolean state) {
+        setConfigFlag(CFG_XML10_ALLOW_ALL_ESCAPED_CHARS, state);
+    }
+
     public void doNormalizeLFs(final boolean state) {
         setConfigFlag(CFG_NORMALIZE_LFS, state);
     }
@@ -1405,7 +1416,8 @@ public final class ReaderConfig
             
         case PROP_TREAT_CHAR_REFS_AS_ENTS:
             return willTreatCharRefsAsEnts() ? Boolean.TRUE : Boolean.FALSE;
-            
+        case PROP_XML10_ALLOW_ALL_ESCAPED_CHARS:
+            return willXml10AllowAllEscapedChars() ? Boolean.TRUE : Boolean.FALSE;
         case PROP_NORMALIZE_LFS:
             return willNormalizeLFs() ? Boolean.TRUE : Boolean.FALSE;
 
@@ -1568,6 +1580,10 @@ public final class ReaderConfig
             
         case PROP_TREAT_CHAR_REFS_AS_ENTS:
             doTreatCharRefsAsEnts(ArgUtil.convertToBoolean(propName, value));
+            break;
+
+        case PROP_XML10_ALLOW_ALL_ESCAPED_CHARS:
+            doXml10AllowAllEscapedChars(ArgUtil.convertToBoolean(propName, value));
             break;
 
         case PROP_NORMALIZE_LFS:

--- a/src/main/java/com/ctc/wstx/api/WstxInputProperties.java
+++ b/src/main/java/com/ctc/wstx/api/WstxInputProperties.java
@@ -77,6 +77,8 @@ public final class WstxInputProperties
      * allowed in XML 1.1.
      *<p>
      * Enable this flag to allow this non compliant content.
+     *
+     * @since 5.2
      */
     public final static String P_XML10_ALLOW_ALL_ESCAPED_CHARS = "com.ctc.wstx.xml10AllowAllEscapedChars";
 

--- a/src/main/java/com/ctc/wstx/api/WstxInputProperties.java
+++ b/src/main/java/com/ctc/wstx/api/WstxInputProperties.java
@@ -70,6 +70,16 @@ public final class WstxInputProperties
      */
     public final static String P_VALIDATE_TEXT_CHARS = "com.ctc.wstx.validateTextChars";
 
+
+    /**
+     * Allow XML 1.1 escaped chars in XML 1.0 file.
+     * Some XML sources advertise XML 1.0 and use escaped characters that are only
+     * allowed in XML 1.1.
+     *<p>
+     * Enable this flag to allow this non compliant content.
+     */
+    public final static String P_XML10_ALLOW_ALL_ESCAPED_CHARS = "com.ctc.wstx.xml10AllowAllEscapedChars";
+
     // // // Caching:
 
     /**

--- a/src/main/java/com/ctc/wstx/cfg/InputConfigFlags.java
+++ b/src/main/java/com/ctc/wstx/cfg/InputConfigFlags.java
@@ -200,5 +200,11 @@ public interface InputConfigFlags
      * 
      */
     final static int CFG_TREAT_CHAR_REFS_AS_ENTS = 0x00800000;
+
+    /**
+     * If true, the XML parser will allow XML 1.1 escaped chars in XML 1.0 file.
+     *
+     */
+    final static int CFG_XML10_ALLOW_ALL_ESCAPED_CHARS = 0x01000000;
 }
 

--- a/src/main/java/com/ctc/wstx/sr/StreamScanner.java
+++ b/src/main/java/com/ctc/wstx/sr/StreamScanner.java
@@ -282,6 +282,11 @@ public abstract class StreamScanner
      */
     protected boolean mNormalizeLFs;
 
+    /**
+     * Flag that indicates whether all escaped chars are accepted in XML 1.0.
+     */
+    protected boolean mXml10AllowAllEscapedChars;
+
     /*
     ///////////////////////////////////////////////////////////////////////
     // Buffer(s) for local name(s) and text content
@@ -384,6 +389,8 @@ public abstract class StreamScanner
         int cf = cfg.getConfigFlags();
         mCfgNsEnabled = (cf & CFG_NAMESPACE_AWARE) != 0;
         mCfgReplaceEntities = (cf & CFG_REPLACE_ENTITY_REFS) != 0;
+
+        mXml10AllowAllEscapedChars = mConfig.willXml10AllowAllEscapedChars();
 
         mNormalizeLFs = mConfig.willNormalizeLFs();
         mInputBuffer = null;
@@ -2395,9 +2402,11 @@ public abstract class StreamScanner
                 throwParseError("Invalid character reference: null character not allowed in XML content.");
             }
             // XML 1.1 allows most other chars; 1.0 does not:
-            if (!mXml11 &&
-                (value != 0x9 && value != 0xA && value != 0xD)) {
-                reportIllegalChar(value);
+            if (!mXml10AllowAllEscapedChars) {
+                if (!mXml11 &&
+                        (value != 0x9 && value != 0xA && value != 0xD)) {
+                    reportIllegalChar(value);
+                }
             }
         }
     }

--- a/src/test/java/stax2/stream/TestXML10AllowAllEscapedChars.java
+++ b/src/test/java/stax2/stream/TestXML10AllowAllEscapedChars.java
@@ -1,0 +1,43 @@
+package stax2.stream;
+
+import com.ctc.wstx.exc.WstxParsingException;
+import org.codehaus.stax2.XMLInputFactory2;
+import stax2.BaseStax2Test;
+
+import javax.xml.stream.XMLStreamReader;
+
+import static com.ctc.wstx.api.WstxInputProperties.P_XML10_ALLOW_ALL_ESCAPED_CHARS;
+
+public class TestXML10AllowAllEscapedChars extends BaseStax2Test {
+    /**
+     * Unit test to verify workaround for XML 1.1 escaped chars in XML 1.0 file.
+     */
+    public void testXML10AllowAllEscapedChars() throws Exception {
+        XMLInputFactory2 f = getInputFactory();
+        setNamespaceAware(f, true);
+        setCoalescing(f, true);
+        f.setProperty(P_XML10_ALLOW_ALL_ESCAPED_CHARS, true);
+        XMLStreamReader sr = constructStreamReader(f, "<?xml version=\"1.0\" encoding=\"utf-8\"?><root>&#x2;</root>");
+        assertTokenType(START_ELEMENT, sr.next());
+        assertTokenType(CHARACTERS, sr.next());
+        assertTokenType(END_ELEMENT, sr.next());
+    }
+
+    /**
+     * Unit test to verify failure for XML 1.1 escaped chars in XML 1.0 file.
+     */
+    public void testXML10DoNotAllowAllEscapedChars() throws Exception {
+        XMLInputFactory2 f = getInputFactory();
+        setNamespaceAware(f, true);
+        setCoalescing(f, true);
+        XMLStreamReader sr = constructStreamReader(f, "<?xml version=\"1.0\" encoding=\"utf-8\"?><root>&#x2;</root>");
+        assertTokenType(START_ELEMENT, sr.next());
+        try {
+            assertTokenType(CHARACTERS, sr.next());
+            fail("Should fail");
+        } catch (WstxParsingException e) {
+            // success
+        }
+        assertTokenType(END_ELEMENT, sr.next());
+    }
+}


### PR DESCRIPTION
DavMail EWS implementation relies on the wonderful Woodstox Stax parser, with just a small issue: Exchange sends XML 1.0 content with XML 1.1 escaped characters.

Currently DavMail source code includes a patched version of StreamScanner to disable this check, I would really like to drop this patch.

This pull request includes a new custom property com.ctc.wstx.xml10AllowAllEscapedChars to allow XML 1.1 escaped characters in XML content.

Note that this is also related to bug #28