### PR TITLE
Rename P_XML10_ALLOW_ALL_ESCAPED_CHARS property to P_ALLOW_XML11_ESCAPED_CHARS_IN_XML10

### DIFF
--- a/src/main/java/com/ctc/wstx/api/ReaderConfig.java
+++ b/src/main/java/com/ctc/wstx/api/ReaderConfig.java
@@ -10,7 +10,6 @@ import org.codehaus.stax2.XMLInputFactory2; // for property consts
 import org.codehaus.stax2.XMLStreamProperties; // for property consts
 import org.codehaus.stax2.validation.DTDValidationSchema;
 
-import com.ctc.wstx.api.WstxInputProperties;
 import com.ctc.wstx.cfg.InputConfigFlags;
 import com.ctc.wstx.dtd.DTDEventListener;
 import com.ctc.wstx.ent.IntEntity;
@@ -106,7 +105,7 @@ public final class ReaderConfig
     /**
      * @since 5.2
      */
-    final static int PROP_XML10_ALLOW_ALL_ESCAPED_CHARS = 47;
+    final static int PROP_ALLOW_XML11_ESCAPED_CHARS_IN_XML10 = 47;
 
     // Object type properties:
 
@@ -306,8 +305,8 @@ public final class ReaderConfig
                         */
         sProperties.put(WstxInputProperties.P_TREAT_CHAR_REFS_AS_ENTS,
                 PROP_TREAT_CHAR_REFS_AS_ENTS);
-        sProperties.put(WstxInputProperties.P_XML10_ALLOW_ALL_ESCAPED_CHARS,
-                PROP_XML10_ALLOW_ALL_ESCAPED_CHARS);
+        sProperties.put(WstxInputProperties.P_ALLOW_XML11_ESCAPED_CHARS_IN_XML10,
+                PROP_ALLOW_XML11_ESCAPED_CHARS_IN_XML10);
         sProperties.put(WstxInputProperties.P_NORMALIZE_LFS, PROP_NORMALIZE_LFS);
         
 
@@ -703,7 +702,7 @@ public final class ReaderConfig
         return _hasConfigFlag(CFG_TREAT_CHAR_REFS_AS_ENTS);
     }
 
-    public boolean willXml10AllowAllEscapedChars() {
+    public boolean willAllowXml11EscapedCharsInXml10() {
         return _hasConfigFlag(CFG_XML10_ALLOW_ALL_ESCAPED_CHARS);
     }
 
@@ -900,7 +899,7 @@ public final class ReaderConfig
         setConfigFlag(CFG_TREAT_CHAR_REFS_AS_ENTS, state);
     }
 
-    public void doXml10AllowAllEscapedChars(final boolean state) {
+    public void doAllowXml11EscapedCharsInXml10(final boolean state) {
         setConfigFlag(CFG_XML10_ALLOW_ALL_ESCAPED_CHARS, state);
     }
 
@@ -1416,8 +1415,8 @@ public final class ReaderConfig
             
         case PROP_TREAT_CHAR_REFS_AS_ENTS:
             return willTreatCharRefsAsEnts() ? Boolean.TRUE : Boolean.FALSE;
-        case PROP_XML10_ALLOW_ALL_ESCAPED_CHARS:
-            return willXml10AllowAllEscapedChars() ? Boolean.TRUE : Boolean.FALSE;
+        case PROP_ALLOW_XML11_ESCAPED_CHARS_IN_XML10:
+            return willAllowXml11EscapedCharsInXml10() ? Boolean.TRUE : Boolean.FALSE;
         case PROP_NORMALIZE_LFS:
             return willNormalizeLFs() ? Boolean.TRUE : Boolean.FALSE;
 
@@ -1582,8 +1581,8 @@ public final class ReaderConfig
             doTreatCharRefsAsEnts(ArgUtil.convertToBoolean(propName, value));
             break;
 
-        case PROP_XML10_ALLOW_ALL_ESCAPED_CHARS:
-            doXml10AllowAllEscapedChars(ArgUtil.convertToBoolean(propName, value));
+        case PROP_ALLOW_XML11_ESCAPED_CHARS_IN_XML10:
+            doAllowXml11EscapedCharsInXml10(ArgUtil.convertToBoolean(propName, value));
             break;
 
         case PROP_NORMALIZE_LFS:

--- a/src/main/java/com/ctc/wstx/api/ReaderConfig.java
+++ b/src/main/java/com/ctc/wstx/api/ReaderConfig.java
@@ -703,7 +703,7 @@ public final class ReaderConfig
     }
 
     public boolean willAllowXml11EscapedCharsInXml10() {
-        return _hasConfigFlag(CFG_XML10_ALLOW_ALL_ESCAPED_CHARS);
+        return _hasConfigFlag(CFG_ALLOW_XML11_ESCAPED_CHARS_IN_XML10);
     }
 
     public int getInputBufferLength() { return mInputBufferLen; }
@@ -900,7 +900,7 @@ public final class ReaderConfig
     }
 
     public void doAllowXml11EscapedCharsInXml10(final boolean state) {
-        setConfigFlag(CFG_XML10_ALLOW_ALL_ESCAPED_CHARS, state);
+        setConfigFlag(CFG_ALLOW_XML11_ESCAPED_CHARS_IN_XML10, state);
     }
 
     public void doNormalizeLFs(final boolean state) {

--- a/src/main/java/com/ctc/wstx/api/WstxInputProperties.java
+++ b/src/main/java/com/ctc/wstx/api/WstxInputProperties.java
@@ -80,7 +80,7 @@ public final class WstxInputProperties
      *
      * @since 5.2
      */
-    public final static String P_XML10_ALLOW_ALL_ESCAPED_CHARS = "com.ctc.wstx.xml10AllowAllEscapedChars";
+    public final static String P_ALLOW_XML11_ESCAPED_CHARS_IN_XML10 = "com.ctc.wstx.allowXml11EscapedCharsInXml10";
 
     // // // Caching:
 

--- a/src/main/java/com/ctc/wstx/cfg/InputConfigFlags.java
+++ b/src/main/java/com/ctc/wstx/cfg/InputConfigFlags.java
@@ -206,5 +206,5 @@ public interface InputConfigFlags
      *
      * @since 5.2
      */
-    final static int CFG_XML10_ALLOW_ALL_ESCAPED_CHARS = 0x01000000;
+    final static int CFG_ALLOW_XML11_ESCAPED_CHARS_IN_XML10 = 0x01000000;
 }

--- a/src/main/java/com/ctc/wstx/sr/StreamScanner.java
+++ b/src/main/java/com/ctc/wstx/sr/StreamScanner.java
@@ -287,7 +287,7 @@ public abstract class StreamScanner
      *
      * @since 5.2
      */
-    protected boolean mXml10AllowAllEscapedChars;
+    protected boolean mAllowXml11EscapedCharsInXml10;
 
     /*
     ///////////////////////////////////////////////////////////////////////
@@ -392,7 +392,7 @@ public abstract class StreamScanner
         mCfgNsEnabled = (cf & CFG_NAMESPACE_AWARE) != 0;
         mCfgReplaceEntities = (cf & CFG_REPLACE_ENTITY_REFS) != 0;
 
-        mXml10AllowAllEscapedChars = mConfig.willXml10AllowAllEscapedChars();
+        mAllowXml11EscapedCharsInXml10 = mConfig.willAllowXml11EscapedCharsInXml10();
 
         mNormalizeLFs = mConfig.willNormalizeLFs();
         mInputBuffer = null;
@@ -2411,7 +2411,7 @@ public abstract class StreamScanner
                 throwParseError("Invalid character reference: null character not allowed in XML content.");
             }
             // XML 1.1 allows most other chars; 1.0 does not:
-            if (!mXml11 && !mXml10AllowAllEscapedChars
+            if (!mXml11 && !mAllowXml11EscapedCharsInXml10
                 && (value != 0x9 && value != 0xA && value != 0xD)) {
                 reportIllegalChar(value);
             }

--- a/src/test/java/stax2/stream/TestAllowXml11EscapedCharsInXml10.java
+++ b/src/test/java/stax2/stream/TestAllowXml11EscapedCharsInXml10.java
@@ -26,7 +26,7 @@ public class TestAllowXml11EscapedCharsInXml10 extends BaseStax2Test {
     /**
      * Unit test to verify failure for XML 1.1 escaped chars in XML 1.0 file.
      */
-    public void testXML10DoNotAllowAllEscapedChars() throws Exception {
+    public void testDoNotAllowXml11EscapedCharsInXml10() throws Exception {
         XMLInputFactory2 f = getInputFactory();
         setNamespaceAware(f, true);
         setCoalescing(f, true);

--- a/src/test/java/stax2/stream/TestAllowXml11EscapedCharsInXml10.java
+++ b/src/test/java/stax2/stream/TestAllowXml11EscapedCharsInXml10.java
@@ -6,17 +6,17 @@ import stax2.BaseStax2Test;
 
 import javax.xml.stream.XMLStreamReader;
 
-import static com.ctc.wstx.api.WstxInputProperties.P_XML10_ALLOW_ALL_ESCAPED_CHARS;
+import static com.ctc.wstx.api.WstxInputProperties.P_ALLOW_XML11_ESCAPED_CHARS_IN_XML10;
 
-public class TestXML10AllowAllEscapedChars extends BaseStax2Test {
+public class TestAllowXml11EscapedCharsInXml10 extends BaseStax2Test {
     /**
      * Unit test to verify workaround for XML 1.1 escaped chars in XML 1.0 file.
      */
-    public void testXML10AllowAllEscapedChars() throws Exception {
+    public void testAllowXml11EscapedCharsInXml10() throws Exception {
         XMLInputFactory2 f = getInputFactory();
         setNamespaceAware(f, true);
         setCoalescing(f, true);
-        f.setProperty(P_XML10_ALLOW_ALL_ESCAPED_CHARS, true);
+        f.setProperty(P_ALLOW_XML11_ESCAPED_CHARS_IN_XML10, true);
         XMLStreamReader sr = constructStreamReader(f, "<?xml version=\"1.0\" encoding=\"utf-8\"?><root>&#x2;</root>");
         assertTokenType(START_ELEMENT, sr.next());
         assertTokenType(CHARACTERS, sr.next());


### PR DESCRIPTION
As suggested in https://github.com/FasterXML/woodstox/pull/56
Also renamed all properties / methods to match the new name.