### PR TITLE
OSGi dependency on relaxng #85

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
 <!--
             <scope>provided</scope>
  -->
+            <optional>true</optional>
         </dependency>
 
 	<!-- 03-Jun-2019, tatu: Not sure why this was added as a dep as it's only one class,


### PR DESCRIPTION
There is a dependency in OSGi on relaxng, which should be optional.