### PR TITLE
check max attribute size precisely

### DIFF
--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -1966,6 +1966,7 @@ public abstract class BasicStreamReader
         int outPtr = tb.getCharSize();
         int outLen = outBuf.length;
         WstxInputSource currScope = mInput;
+        final int maxAttributeSize = mConfig.getMaxAttributeSize();
 
         while (true) {
             char c = (mInputPtr < mInputEnd) ? mInputBuffer[mInputPtr++]
@@ -2034,9 +2035,10 @@ public abstract class BasicStreamReader
                 throwUnexpectedChar(c, SUFFIX_IN_ATTR_VALUE);
             }
 
+            verifyLimit("Maximum attribute size", maxAttributeSize, outPtr);
+
             // Ok, let's just add char in, whatever it was
             if (outPtr >= outLen) {
-                verifyLimit("Maximum attribute size", mConfig.getMaxAttributeSize(), tb.getCharSize());
                 outBuf = tb.bufferFull(1);
                 outLen = outBuf.length;
             }

--- a/src/test/java/stax2/BaseStax2Test.java
+++ b/src/test/java/stax2/BaseStax2Test.java
@@ -3,6 +3,7 @@ package stax2;
 import java.io.*;
 import java.util.HashMap;
 
+import com.ctc.wstx.api.WstxInputProperties;
 import junit.framework.TestCase;
 
 import javax.xml.stream.*;
@@ -275,6 +276,12 @@ public abstract class BaseStax2Test
     {
         f.setProperty(XMLInputFactory2.P_LAZY_PARSING,
                       state ? Boolean.TRUE : Boolean.FALSE);
+    }
+
+    protected static void setMaxAttributeSize(XMLInputFactory f, int maxAttributeSize)
+        throws XMLStreamException
+    {
+        f.setProperty(WstxInputProperties.P_MAX_ATTRIBUTE_SIZE, Integer.valueOf(maxAttributeSize));
     }
 
     /*

--- a/src/test/java/stax2/typed/WriterTestBase.java
+++ b/src/test/java/stax2/typed/WriterTestBase.java
@@ -944,6 +944,7 @@ public abstract class WriterTestBase
         XMLInputFactory f = getInputFactory();
         setCoalescing(f, false); // shouldn't really matter
         setNamespaceAware(f, true);
+        setMaxAttributeSize(f, 1048576);
         return (XMLStreamReader2) f.createXMLStreamReader(new ByteArrayInputStream(data));
     }
 


### PR DESCRIPTION
A fix + test-case for https://github.com/FasterXML/woodstox/issues/93 . 