### PR TITLE
Fix #142 (multiple text events for long segments if requested)

### DIFF
--- a/src/main/java/com/ctc/wstx/api/ReaderConfig.java
+++ b/src/main/java/com/ctc/wstx/api/ReaderConfig.java
@@ -818,6 +818,18 @@ public final class ReaderConfig
         return _hasExplicitConfigFlag(CFG_INTERN_NS_URIS);
     }
 
+    /**
+     * Checks if the user explicitly set coalescing to false. (That is if
+     * coalescing is disabled only because that is the default value, this method
+     * will return false.)
+     *
+     * @return true, if the user explicitly disabled coalescing, else false
+     */
+    public boolean isCoalescingExplicitlyDisabled() {
+        // coalescing is disabled and was explicitly set by user
+        return !_hasConfigFlag(CFG_COALESCE_TEXT) && (mConfigFlagMods & CFG_COALESCE_TEXT) != 0;
+    }
+
     /*
     ///////////////////////////////////////////////////////////////////////
     // Simple mutators

--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -434,10 +434,10 @@ public abstract class BasicStreamReader
             mShortestTextSegment = Integer.MAX_VALUE;
         } else {
             mStTextThreshold =  TOKEN_PARTIAL_SINGLE;
-            if (forER) {
+            if (forER && !cfg.isCoalescingExplicitlyDisabled()) {
                 /* 30-Sep-2005, TSa: No point in returning runt segments for event readers
                  *   (due to event object overhead, less convenient); let's just force
-                 *   returning of full length segments.
+                 *   returning of full length segments. (Unless explicitly requested.)
                  */
                 mShortestTextSegment = Integer.MAX_VALUE;
             } else {


### PR DESCRIPTION
As discussed in #142, if coalescing was explicitly set to false by the user, text segments may be returned in multiple text events.