### PR TITLE
Add standard osgi.serviceloader OSGi metadata for provided services.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@ SAX2 and Stax2 APIs
         -->
       <osgi.export>com.ctc.wstx.*;version=${project.version}</osgi.export>
 
+      <!-- Bnd annotations for generating extra OSGi metadata. -->
+      <version.bnd.annotation>6.3.1</version.bnd.annotation>
+
       <!-- 5.1 added "Automatic-Module-Name" for JDK 9 but 6.0 adds full module-info -->
 <!--
       <jdk.module.name>com.ctc.wstx</jdk.module.name>
@@ -144,11 +147,19 @@ SAX2 and Stax2 APIs
 
         <!-- Then OSGi, needed if using OSGi discovery -->
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.osgi.core</artifactId>
-            <version>1.4.0</version>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+            <version>5.0.0</version>
             <optional>true</optional>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>biz.aQute.bnd.annotation</artifactId>
+          <version>${version.bnd.annotation}</version>
+          <optional>true</optional>
+          <scope>provided</scope>
         </dependency>
 
         <!-- Then test deps -->

--- a/src/main/java/com/ctc/wstx/dtd/DTDSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/dtd/DTDSchemaFactory.java
@@ -20,6 +20,7 @@ import java.net.URL;
 
 import javax.xml.stream.*;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.codehaus.stax2.validation.*;
 
 import com.ctc.wstx.api.ReaderConfig;
@@ -40,6 +41,7 @@ import com.ctc.wstx.util.URLUtil;
  * documents) is only accessible by core Woodstox. The externally
  * accessible
  */
+@ServiceProvider(XMLValidationSchemaFactory.class)
 public class DTDSchemaFactory
     extends XMLValidationSchemaFactory
 {

--- a/src/main/java/com/ctc/wstx/msv/RelaxNGSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/msv/RelaxNGSchemaFactory.java
@@ -18,6 +18,7 @@ package com.ctc.wstx.msv;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.*;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.xml.sax.InputSource;
 
 import org.codehaus.stax2.validation.*;
@@ -35,6 +36,7 @@ import com.sun.msv.reader.trex.ng.RELAXNGReader;
  * to work, and acts as a quite thin wrapper layer (although not a completely
  * trivial one, since MSV only exports SAX API, some adapting is needed)
  */
+@ServiceProvider(XMLValidationSchemaFactory.class)
 public class RelaxNGSchemaFactory
     extends BaseSchemaFactory
 {

--- a/src/main/java/com/ctc/wstx/msv/W3CSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/msv/W3CSchemaFactory.java
@@ -18,6 +18,7 @@ package com.ctc.wstx.msv;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.*;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.xml.sax.InputSource;
 
 import org.codehaus.stax2.validation.*;
@@ -35,6 +36,7 @@ import com.sun.msv.reader.xmlschema.XMLSchemaReader;
  * to work, and acts as a quite thin wrapper layer, similar to
  * how matching RelaxNG validator works
  */
+@ServiceProvider(XMLValidationSchemaFactory.class)
 public class W3CSchemaFactory
     extends BaseSchemaFactory
 {

--- a/src/main/java/com/ctc/wstx/stax/WstxEventFactory.java
+++ b/src/main/java/com/ctc/wstx/stax/WstxEventFactory.java
@@ -22,6 +22,7 @@ import javax.xml.namespace.QName;
 import javax.xml.stream.*;
 import javax.xml.stream.events.*;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.codehaus.stax2.ri.Stax2EventFactoryImpl;
 
 import com.ctc.wstx.compat.QNameCreator;
@@ -31,6 +32,7 @@ import com.ctc.wstx.evt.*;
  * Implementation of {@link XMLEventFactory} to be used with
  * Woodstox. Contains minimal additions on top of Stax2 RI.
  */
+@ServiceProvider(XMLEventFactory.class)
 public final class WstxEventFactory
     extends Stax2EventFactoryImpl
 {

--- a/src/main/java/com/ctc/wstx/stax/WstxInputFactory.java
+++ b/src/main/java/com/ctc/wstx/stax/WstxInputFactory.java
@@ -24,6 +24,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamSource;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.xml.sax.InputSource;
 import org.codehaus.stax2.XMLEventReader2;
 import org.codehaus.stax2.XMLInputFactory2;
@@ -68,6 +69,7 @@ import com.ctc.wstx.util.URLUtil;
  *
  * @author Tatu Saloranta
  */
+@ServiceProvider(XMLInputFactory.class)
 public class WstxInputFactory
     extends XMLInputFactory2
     implements ReaderCreator,

--- a/src/main/java/com/ctc/wstx/stax/WstxOutputFactory.java
+++ b/src/main/java/com/ctc/wstx/stax/WstxOutputFactory.java
@@ -29,6 +29,7 @@ import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamResult;
 
+import aQute.bnd.annotation.spi.ServiceProvider;
 import org.codehaus.stax2.XMLOutputFactory2;
 import org.codehaus.stax2.XMLStreamWriter2;
 import org.codehaus.stax2.io.Stax2Result;
@@ -61,6 +62,7 @@ import com.ctc.wstx.util.URLUtil;
  *  </li>
  *</ul>
  */
+@ServiceProvider(XMLOutputFactory.class)
 public class WstxOutputFactory
     extends XMLOutputFactory2
     implements OutputConfigFlags

--- a/src/main/resources/META-INF/services/org.codehaus.stax2.validation.XMLValidationSchemaFactory
+++ b/src/main/resources/META-INF/services/org.codehaus.stax2.validation.XMLValidationSchemaFactory
@@ -1,0 +1,3 @@
+com.ctc.wstx.dtd.DTDSchemaFactory
+com.ctc.wstx.msv.RelaxNGSchemaFactory
+com.ctc.wstx.msv.W3CSchemaFactory


### PR DESCRIPTION
Add OSGi metadata so that an OSGi framework can consume this bundle's SPI services.

The standard service loader mediator is [Apache Aries SPI-Fly](https://aries.apache.org/documentation/modules/spi-fly.html).