### PR TITLE
Declare osgi.serviceloader.registrar requirement as optional.

### DIFF
--- a/src/main/java/com/ctc/wstx/dtd/DTDSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/dtd/DTDSchemaFactory.java
@@ -32,6 +32,8 @@ import com.ctc.wstx.util.DefaultXmlSymbolTable;
 import com.ctc.wstx.util.SymbolTable;
 import com.ctc.wstx.util.URLUtil;
 
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
+
 /**
  * Factory for creating DTD validator schema objects (shareable stateless
  * "blueprints" for creating actual validators).
@@ -41,7 +43,7 @@ import com.ctc.wstx.util.URLUtil;
  * documents) is only accessible by core Woodstox. The externally
  * accessible
  */
-@ServiceProvider(XMLValidationSchemaFactory.class)
+@ServiceProvider(value = XMLValidationSchemaFactory.class, resolution = OPTIONAL)
 public class DTDSchemaFactory
     extends XMLValidationSchemaFactory
 {

--- a/src/main/java/com/ctc/wstx/msv/RelaxNGSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/msv/RelaxNGSchemaFactory.java
@@ -27,6 +27,8 @@ import com.sun.msv.grammar.trex.TREXGrammar;
 import com.sun.msv.reader.GrammarReaderController;
 import com.sun.msv.reader.trex.ng.RELAXNGReader;
 
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
+
 /**
  * This is a StAX2 schema factory that can parse and create schema instances
  * for creating validators that validate documents to check their validity
@@ -36,7 +38,7 @@ import com.sun.msv.reader.trex.ng.RELAXNGReader;
  * to work, and acts as a quite thin wrapper layer (although not a completely
  * trivial one, since MSV only exports SAX API, some adapting is needed)
  */
-@ServiceProvider(XMLValidationSchemaFactory.class)
+@ServiceProvider(value = XMLValidationSchemaFactory.class, resolution = OPTIONAL)
 public class RelaxNGSchemaFactory
     extends BaseSchemaFactory
 {

--- a/src/main/java/com/ctc/wstx/msv/W3CSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/msv/W3CSchemaFactory.java
@@ -27,6 +27,8 @@ import com.sun.msv.grammar.xmlschema.XMLSchemaGrammar;
 import com.sun.msv.reader.GrammarReaderController;
 import com.sun.msv.reader.xmlschema.XMLSchemaReader;
 
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
+
 /**
  * This is a StAX2 schema factory that can parse and create schema instances
  * for creating validators that validate documents to check their validity
@@ -36,7 +38,7 @@ import com.sun.msv.reader.xmlschema.XMLSchemaReader;
  * to work, and acts as a quite thin wrapper layer, similar to
  * how matching RelaxNG validator works
  */
-@ServiceProvider(XMLValidationSchemaFactory.class)
+@ServiceProvider(value = XMLValidationSchemaFactory.class, resolution = OPTIONAL)
 public class W3CSchemaFactory
     extends BaseSchemaFactory
 {

--- a/src/main/java/com/ctc/wstx/stax/WstxEventFactory.java
+++ b/src/main/java/com/ctc/wstx/stax/WstxEventFactory.java
@@ -28,11 +28,13 @@ import org.codehaus.stax2.ri.Stax2EventFactoryImpl;
 import com.ctc.wstx.compat.QNameCreator;
 import com.ctc.wstx.evt.*;
 
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
+
 /**
  * Implementation of {@link XMLEventFactory} to be used with
  * Woodstox. Contains minimal additions on top of Stax2 RI.
  */
-@ServiceProvider(XMLEventFactory.class)
+@ServiceProvider(value = XMLEventFactory.class, resolution = OPTIONAL)
 public final class WstxEventFactory
     extends Stax2EventFactoryImpl
 {

--- a/src/main/java/com/ctc/wstx/stax/WstxInputFactory.java
+++ b/src/main/java/com/ctc/wstx/stax/WstxInputFactory.java
@@ -54,6 +54,8 @@ import com.ctc.wstx.util.SimpleCache;
 import com.ctc.wstx.util.SymbolTable;
 import com.ctc.wstx.util.URLUtil;
 
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
+
 /**
  * Factory for creating various Stax objects (stream/event reader,
  * writer).
@@ -69,7 +71,7 @@ import com.ctc.wstx.util.URLUtil;
  *
  * @author Tatu Saloranta
  */
-@ServiceProvider(XMLInputFactory.class)
+@ServiceProvider(value = XMLInputFactory.class, resolution = OPTIONAL)
 public class WstxInputFactory
     extends XMLInputFactory2
     implements ReaderCreator,

--- a/src/main/java/com/ctc/wstx/stax/WstxOutputFactory.java
+++ b/src/main/java/com/ctc/wstx/stax/WstxOutputFactory.java
@@ -52,6 +52,8 @@ import com.ctc.wstx.sw.SimpleNsStreamWriter;
 import com.ctc.wstx.sw.XmlWriter;
 import com.ctc.wstx.util.URLUtil;
 
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
+
 /**
  * Implementation of {@link XMLOutputFactory} for Wstx.
  *<p>
@@ -62,7 +64,7 @@ import com.ctc.wstx.util.URLUtil;
  *  </li>
  *</ul>
  */
-@ServiceProvider(XMLOutputFactory.class)
+@ServiceProvider(value = XMLOutputFactory.class, resolution = OPTIONAL)
 public class WstxOutputFactory
     extends XMLOutputFactory2
     implements OutputConfigFlags


### PR DESCRIPTION
The `osgi.serviceloader.registrar` requirement is satisfied by [Apache Aries SPI-Fly](https://repo1.maven.org/maven2/org/apache/aries/spifly/org.apache.aries.spifly.dynamic.framework.extension), and `java.util.ServiceLoader` _cannot_ work inside an OSGi framework without it.

However, it is probably better to allow people to discover a need for SPI-Fly themselves rather that throwing bundle resolution errors at them when they upgrade `woodstox-core` :blush:.