### PR TITLE
Fix #163: Revert "Declare `osgi.serviceloader.registrar` requirement as optional"

### DIFF
--- a/src/main/java/com/ctc/wstx/dtd/DTDSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/dtd/DTDSchemaFactory.java
@@ -32,8 +32,6 @@ import com.ctc.wstx.util.DefaultXmlSymbolTable;
 import com.ctc.wstx.util.SymbolTable;
 import com.ctc.wstx.util.URLUtil;
 
-import static aQute.bnd.annotation.Resolution.OPTIONAL;
-
 /**
  * Factory for creating DTD validator schema objects (shareable stateless
  * "blueprints" for creating actual validators).
@@ -43,7 +41,7 @@ import static aQute.bnd.annotation.Resolution.OPTIONAL;
  * documents) is only accessible by core Woodstox. The externally
  * accessible
  */
-@ServiceProvider(value = XMLValidationSchemaFactory.class, resolution = OPTIONAL)
+@ServiceProvider(XMLValidationSchemaFactory.class)
 public class DTDSchemaFactory
     extends XMLValidationSchemaFactory
 {

--- a/src/main/java/com/ctc/wstx/msv/RelaxNGSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/msv/RelaxNGSchemaFactory.java
@@ -27,8 +27,6 @@ import com.sun.msv.grammar.trex.TREXGrammar;
 import com.sun.msv.reader.GrammarReaderController;
 import com.sun.msv.reader.trex.ng.RELAXNGReader;
 
-import static aQute.bnd.annotation.Resolution.OPTIONAL;
-
 /**
  * This is a StAX2 schema factory that can parse and create schema instances
  * for creating validators that validate documents to check their validity
@@ -38,7 +36,7 @@ import static aQute.bnd.annotation.Resolution.OPTIONAL;
  * to work, and acts as a quite thin wrapper layer (although not a completely
  * trivial one, since MSV only exports SAX API, some adapting is needed)
  */
-@ServiceProvider(value = XMLValidationSchemaFactory.class, resolution = OPTIONAL)
+@ServiceProvider(XMLValidationSchemaFactory.class)
 public class RelaxNGSchemaFactory
     extends BaseSchemaFactory
 {

--- a/src/main/java/com/ctc/wstx/msv/W3CSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/msv/W3CSchemaFactory.java
@@ -27,8 +27,6 @@ import com.sun.msv.grammar.xmlschema.XMLSchemaGrammar;
 import com.sun.msv.reader.GrammarReaderController;
 import com.sun.msv.reader.xmlschema.XMLSchemaReader;
 
-import static aQute.bnd.annotation.Resolution.OPTIONAL;
-
 /**
  * This is a StAX2 schema factory that can parse and create schema instances
  * for creating validators that validate documents to check their validity
@@ -38,7 +36,7 @@ import static aQute.bnd.annotation.Resolution.OPTIONAL;
  * to work, and acts as a quite thin wrapper layer, similar to
  * how matching RelaxNG validator works
  */
-@ServiceProvider(value = XMLValidationSchemaFactory.class, resolution = OPTIONAL)
+@ServiceProvider(XMLValidationSchemaFactory.class)
 public class W3CSchemaFactory
     extends BaseSchemaFactory
 {

--- a/src/main/java/com/ctc/wstx/stax/WstxEventFactory.java
+++ b/src/main/java/com/ctc/wstx/stax/WstxEventFactory.java
@@ -28,13 +28,11 @@ import org.codehaus.stax2.ri.Stax2EventFactoryImpl;
 import com.ctc.wstx.compat.QNameCreator;
 import com.ctc.wstx.evt.*;
 
-import static aQute.bnd.annotation.Resolution.OPTIONAL;
-
 /**
  * Implementation of {@link XMLEventFactory} to be used with
  * Woodstox. Contains minimal additions on top of Stax2 RI.
  */
-@ServiceProvider(value = XMLEventFactory.class, resolution = OPTIONAL)
+@ServiceProvider(XMLEventFactory.class)
 public final class WstxEventFactory
     extends Stax2EventFactoryImpl
 {

--- a/src/main/java/com/ctc/wstx/stax/WstxInputFactory.java
+++ b/src/main/java/com/ctc/wstx/stax/WstxInputFactory.java
@@ -54,8 +54,6 @@ import com.ctc.wstx.util.SimpleCache;
 import com.ctc.wstx.util.SymbolTable;
 import com.ctc.wstx.util.URLUtil;
 
-import static aQute.bnd.annotation.Resolution.OPTIONAL;
-
 /**
  * Factory for creating various Stax objects (stream/event reader,
  * writer).
@@ -71,7 +69,7 @@ import static aQute.bnd.annotation.Resolution.OPTIONAL;
  *
  * @author Tatu Saloranta
  */
-@ServiceProvider(value = XMLInputFactory.class, resolution = OPTIONAL)
+@ServiceProvider(XMLInputFactory.class)
 public class WstxInputFactory
     extends XMLInputFactory2
     implements ReaderCreator,

--- a/src/main/java/com/ctc/wstx/stax/WstxOutputFactory.java
+++ b/src/main/java/com/ctc/wstx/stax/WstxOutputFactory.java
@@ -52,8 +52,6 @@ import com.ctc.wstx.sw.SimpleNsStreamWriter;
 import com.ctc.wstx.sw.XmlWriter;
 import com.ctc.wstx.util.URLUtil;
 
-import static aQute.bnd.annotation.Resolution.OPTIONAL;
-
 /**
  * Implementation of {@link XMLOutputFactory} for Wstx.
  *<p>
@@ -64,7 +62,7 @@ import static aQute.bnd.annotation.Resolution.OPTIONAL;
  *  </li>
  *</ul>
  */
-@ServiceProvider(value = XMLOutputFactory.class, resolution = OPTIONAL)
+@ServiceProvider(XMLOutputFactory.class)
 public class WstxOutputFactory
     extends XMLOutputFactory2
     implements OutputConfigFlags


### PR DESCRIPTION
Reverts FasterXML/woodstox#155