### PR TITLE
Wrong line for XML event location in elements following DTD [WSTX-67]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@ SAX2 and Stax2 APIs
         <url>http://fasterxml.com</url>
     </organization>
     <url>https://github.com/FasterXML/woodstox</url>
+    <!--
     <issueManagement>
         <url>https://github.com/FasterXML/woodstox/issues</url>
     </issueManagement>
@@ -36,15 +37,23 @@ SAX2 and Stax2 APIs
         <url>https://github.com/FasterXML/woodstox</url>
         <tag>HEAD</tag>
     </scm>
-
+	-->
+	
     <properties>
-      <version.msv>2013.6.1</version.msv>
+      <version.msv>2022.8-SNAPSHOT</version.msv>
       <version.plugin.javadoc>3.1.1</version.plugin.javadoc>
 
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>        
+      <skipTests>false</skipTests>
+        
       <!-- Woodstox 5.0 is 1.6+ -->
-      <javac.src.version>1.6</javac.src.version>
-      <javac.target.version>1.6</javac.target.version>
+      <jdk.version>1.8</jdk.version>
+      <javac.src.version>1.8</javac.src.version>
+      <javac.target.version>1.8</javac.target.version>
 
+	  <maven.compiler.source>1.8</maven.compiler.source>
+	  <maven.compiler.target>1.8</maven.compiler.target>
+	  
       <!-- Since our groupId is NOT the same as Java package id, need to explicitly define.
            And due to number of packages, let's just include all.
         -->
@@ -103,7 +112,7 @@ SAX2 and Stax2 APIs
         <dependency>
             <groupId>net.java.dev.msv</groupId>
             <artifactId>msv-core</artifactId>
-            <version>${version.msv}</version>
+            <version>2022.8-SNAPSHOT</version>
 <!--
             <scope>provided</scope>
        -->
@@ -201,7 +210,8 @@ SAX2 and Stax2 APIs
 
                to simplify releases. I hope.
           -->
-	<plugin>
+          <!-- 
+		<plugin>		
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
             <version>1.6.6</version>
@@ -209,21 +219,21 @@ SAX2 and Stax2 APIs
             <configuration>
               <serverId>sonatype-nexus-staging</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <!-- 12-Oct-2019, tatu: Found this from output of mvn:relase -->
               <stagingProfileId>b34f19b9cc6224</stagingProfileId>
             </configuration>
         </plugin>
-
+		-->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                 <version>3.11.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
 <!--
                     <excludes>
                         <exclude>test/**</exclude>
                     </excludes>
--->
+--> 
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/ctc/wstx/dtd/MinimalDTDReader.java
+++ b/src/main/java/com/ctc/wstx/dtd/MinimalDTDReader.java
@@ -320,6 +320,7 @@ public class MinimalDTDReader
                 if (c == '-') {
                     return;
                 }
+                if (c == '\n') skipCRLF(c);
             } else if (c == '\n' || c == '\r') {
                 skipCRLF(c);
             }

--- a/src/test/java/failing/TestW3CSchemaNillable179.java
+++ b/src/test/java/failing/TestW3CSchemaNillable179.java
@@ -25,7 +25,7 @@ import wstxtest.vstream.BaseValidationTest;
 public class TestW3CSchemaNillable179
     extends BaseValidationTest
 {
-    // for [woodstox-core#179
+    // for [woodstox-core#179]
     public void testNillableDateTime() throws Exception
     {
         /*
@@ -36,7 +36,7 @@ public class TestW3CSchemaNillable179
         testNillable("wstxtest/msv/nillableDateTime.xml");
     }
 
-    // for [woodstox-core#179
+    // for [woodstox-core#179]
     public void testNillableInt() throws Exception
     {
         /*
@@ -47,7 +47,7 @@ public class TestW3CSchemaNillable179
         testNillable("wstxtest/msv/nillableInt.xml");
     }
 
-    // for [woodstox-core#179
+    // for [woodstox-core#179]
     public void testNillableString() throws Exception
     {
         /*

--- a/src/test/java/wstxtest/msv/Issue_175_ver1.xml
+++ b/src/test/java/wstxtest/msv/Issue_175_ver1.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<main:Issue175 xmlns:main="http://www.example.org/issue_175_main"
+			   xmlns:imprt="http://www.example.org/issue_175_import"
+			   main:XmlVersion="1"
+			   imprt:XmlVersion="1" >
+	<main:Data imprt:Attrib1="Attribute #1 - Ver1"
+			   imprt:Attrib2="Attribute #2 - Ver1" >
+		<main:Element1>Element #1 from Version 1</main:Element1>
+		<main:Element2>12345</main:Element2>
+		<main:Element3 imprt:Attrib3="true">Element #2 from Version 1</main:Element3>
+		<main:Element4>ENUM4</main:Element4>
+	</main:Data>
+</main:Issue175>

--- a/src/test/java/wstxtest/msv/Issue_175_ver2.xml
+++ b/src/test/java/wstxtest/msv/Issue_175_ver2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<main:Issue175 xmlns:main="http://www.example.org/issue_175_main"
+			   xmlns:imprt="http://www.example.org/issue_175_import"
+			   main:XmlVersion="2"
+			   imprt:XmlVersion="1" >
+	<main:Data imprt:Attrib1="Attribute #1 - Ver1"
+			   imprt:Attrib2="Attribute #2 - Ver1" >
+		<main:Element1>Element #1 from Version 2</main:Element1>
+		<main:Element2>12345</main:Element2>
+		<main:Element3 imprt:Attrib3="false">Element #2 from Version 2</main:Element3>
+		<main:Element4>ENUM1</main:Element4>
+		<main:Element5>Element #2 from Version 2</main:Element5>
+	</main:Data>
+</main:Issue175>

--- a/src/test/java/wstxtest/msv/Issue_175_ver3.xml
+++ b/src/test/java/wstxtest/msv/Issue_175_ver3.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<main:Issue175 xmlns:main="http://www.example.org/issue_175_main"
+			   xmlns:imprt="http://www.example.org/issue_175_import"
+			   main:XmlVersion="3"
+			   imprt:XmlVersion="2" >
+	<main:Data imprt:Attrib1="Attribute #1 - Ver1"
+			   imprt:Attrib2="Attribute #2 - Ver1" 
+			   imprt:Attrib4="false">
+		<main:Element1>Element #1 from Main Version 1</main:Element1>
+		<main:Element2>12345</main:Element2>
+		<main:Element3 imprt:Attrib3="true">Element #2 from Main Version 3</main:Element3>
+		<main:Element4 imprt:Attrib5="New attrib Import Ver 2">ENUM2</main:Element4>
+		<main:Element5>Element #5 from Main Version 3</main:Element5>
+	</main:Data>
+</main:Issue175>

--- a/src/test/java/wstxtest/msv/TestIssue_175.java
+++ b/src/test/java/wstxtest/msv/TestIssue_175.java
@@ -1,0 +1,620 @@
+package wstxtest.msv;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+
+import org.codehaus.stax2.XMLStreamReader2;
+import org.codehaus.stax2.validation.ValidationProblemHandler;
+import org.codehaus.stax2.validation.XMLValidationException;
+import org.codehaus.stax2.validation.XMLValidationProblem;
+import org.codehaus.stax2.validation.XMLValidationSchema;
+import org.junit.Assert;
+import org.junit.Test;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import com.ctc.wstx.msv.W3CMultiSchemaFactory;
+import com.ctc.wstx.stax.WstxInputFactory;
+
+/**
+ * Test Issue_175 - Added to test resolving XSD source files using the Entity Resolver
+ *     
+ *  When using various versions of XML that is build using imported XSD, in order to validate the XML correctly, the schema
+ *  validation object must be built using the correct XSD.  Typically, the main XSD uses an generic import to the XSD built
+ *  with.  In this scenario, the correct XSD must be resolved in order for the XML Validation to work correctly.
+ *  
+ *  In this test, two separate folders containing the versioned XSDs is used to demonstrate.  The developer could have placed 
+ *  all the versioned XSDs in the same 'schema' folder.
+ *  
+ * @author Tim Martin
+ */
+public class TestIssue_175 
+{	
+	@Test
+	/**
+	 *  This tests in the case where the XSDs import statements files names/path do not match the file/path and naming 
+	 *  used in the implementation.
+	 */		
+	public void testReadWithNoEntityResolver() 
+	{
+		try 
+		{
+			// Build Schema Validation object for Version 1
+    		File fMainXsd1 = new File(getClass().getResource("schema/main/issue_175_main_v1.xsd").getFile());
+    		final File fImportXsd1 = new File(getClass().getResource("schema/import/issue_175_import_v1.xsd").getFile());
+    		
+    		// Test to make sure we picked up the XSD
+    		Assert.assertTrue(fMainXsd1.exists());
+    		Assert.assertTrue(fImportXsd1.exists());
+    		
+        	final Map<String, Source> schemas_Ver1 = new HashMap<>();
+        	schemas_Ver1.put("http://www.example.org/issue_175_main", new StreamSource(fMainXsd1));
+        	schemas_Ver1.put("http://www.example.org/issue_175_import", new StreamSource(fImportXsd1));
+        	
+    		final W3CMultiSchemaFactory sf = new W3CMultiSchemaFactory();
+        	sf.createSchema(null, schemas_Ver1);
+        	
+        	Assert.fail("Exception should have been thrown");
+		}
+		catch (XMLStreamException xse)
+		{
+			Assert.assertEquals("Failed to load schemas", xse.getMessage());
+		}
+		
+		try
+		{
+   	  		// Build Schema Validation object for Version 2    		
+   			final File fMainXsd2 = new File(getClass().getResource("schema/main/issue_175_main_v2.xsd").getFile());
+   			final File fImportXsd2 = new File(getClass().getResource("schema/import/issue_175_import_v1.xsd").getFile());
+   			    		
+   			final Map<String, Source> schemas_Ver2 = new HashMap<>();
+   	    	schemas_Ver2.put("http://www.example.org/issue_175_main", new StreamSource(fMainXsd2));
+   	    	schemas_Ver2.put("http://www.example.org/issue_175_import", new StreamSource(fImportXsd2));
+   			        	
+   	    	final W3CMultiSchemaFactory sf = new W3CMultiSchemaFactory();
+   			sf.createSchema(null, schemas_Ver2);
+		}
+		catch (XMLStreamException xse)
+		{
+			Assert.assertEquals("Failed to load schemas", xse.getMessage());
+		}   			
+   			
+        try
+        {
+   			// Build Schema Validation object for Version 3    		
+   			final File fMainXsd3 = new File(getClass().getResource("schema/main/issue_175_main_v3.xsd").getFile());
+   			final File fImportXsd3 = new File(getClass().getResource("schema/import/issue_175_import_v2.xsd").getFile());
+   			    		
+   			final Map<String, Source> schemas_Ver3 = new HashMap<>();
+   	    	schemas_Ver3.put("http://www.example.org/issue_175_main", new StreamSource(fMainXsd3));
+   	    	schemas_Ver3.put("http://www.example.org/issue_175_import", new StreamSource(fImportXsd3));
+   			        	
+   	    	final W3CMultiSchemaFactory sf = new W3CMultiSchemaFactory();
+   			sf.createSchema(null, schemas_Ver3);   			
+		}
+		catch (XMLStreamException xse)
+		{
+			Assert.assertEquals("Failed to load schemas", xse.getMessage());
+		}	
+	}		
+	
+	@Test
+	/**
+	 *  This tests in the case where the XML version matches the schema version, this validates the correct XSDs
+	 *  are being picked up.
+	 */		
+	public void testValidationWithEntityResolver() 
+	{
+		try 
+		{
+			// Build Schema Validation object for Version 1
+    		File fMainXsd1 = new File(getClass().getResource("schema/main/issue_175_main_v1.xsd").getFile());
+    		final File fImportXsd1 = new File(getClass().getResource("schema/import/issue_175_import_v1.xsd").getFile());
+    		
+    		// Test to make sure we picked up the XSD
+    		Assert.assertTrue(fMainXsd1.exists());
+    		Assert.assertTrue(fImportXsd1.exists());
+    		
+        	final Map<String, Source> schemas_Ver1 = new HashMap<>();
+        	schemas_Ver1.put("http://www.example.org/issue_175_main", new StreamSource(fMainXsd1));
+        	schemas_Ver1.put("http://www.example.org/issue_175_import", new StreamSource(fImportXsd1));
+        	
+    		final W3CMultiSchemaFactory sf = new W3CMultiSchemaFactory();
+        	sf.setEntityResolver(new EntityResolver() {
+    			@Override
+    			public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException 
+    			{							
+    	        	System.out.println("ResolveEntity() - Public id: [" + publicId + "], System id: [" + systemId + "]");
+    	        	
+    	        	InputSource is = null;
+    	        	
+    	        	File tmp = new File(URI.create(systemId).getPath());
+    	        	
+    	        	String fileName = tmp.getName();
+    	        	if ("issue_175_import.xsd".equalsIgnoreCase(fileName))
+    	        	{
+    	        		tmp = fImportXsd1;
+    	        	}
+    	        	
+    	        	try
+    	        	{
+    	        		is = new InputSource(new FileReader(tmp));
+    	        		is.setSystemId(tmp.toURI().toString());
+    	        	}
+    	        	catch (IOException ex)
+        			{
+        				ex.printStackTrace();
+        			}
+    	        	
+    	        	System.out.println("ResolveEntity() - System Id: [" + is.getSystemId() + "]");
+    	        	
+    				return is;
+    			}				
+    		});
+        	
+        	final XMLValidationSchema valSchemaVal_Ver1 = sf.createSchema(null, schemas_Ver1);
+        	    		
+   	  		// Build Schema Validation object for Version 2    		
+   			final File fMainXsd2 = new File(getClass().getResource("schema/main/issue_175_main_v2.xsd").getFile());
+   			final File fImportXsd2 = new File(getClass().getResource("schema/import/issue_175_import_v1.xsd").getFile());
+   			    		
+   			final Map<String, Source> schemas_Ver2 = new HashMap<>();
+   	    	schemas_Ver2.put("http://www.example.org/issue_175_main", new StreamSource(fMainXsd2));
+   	    	schemas_Ver2.put("http://www.example.org/issue_175_import", new StreamSource(fImportXsd2));
+   			        	
+   			final XMLValidationSchema valSchemaVal_Ver2 = sf.createSchema(null, schemas_Ver2, new EntityResolver() {
+   				@Override
+   				public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException 
+   				{							
+   		        	System.out.println("ResolveEntity() - Public id: [" + publicId + "], System id: [" + systemId + "]");
+   		        	
+   		        	InputSource is = null;
+   		        	
+   		        	File tmp = new File(URI.create(systemId).getPath());
+   		        	
+   		        	String fileName = tmp.getName();
+   		        	if ("issue_175_import.xsd".equalsIgnoreCase(fileName))
+   		        	{
+   		        		tmp = fImportXsd2;
+   		        	}
+   		        	
+   		        	try
+   		        	{
+   		        		is = new InputSource(new FileReader(tmp));
+   		        		is.setSystemId(tmp.toURI().toString());
+   		        	}
+   		        	catch (IOException ex)
+   	    			{
+   	    				ex.printStackTrace();
+   	    			}
+   		        	
+   		        	System.out.println("ResolveEntity() - System Id: [" + is.getSystemId() + "]");
+   		        	
+   					return is;
+   				}				
+   			});
+        	
+   			// Build Schema Validation object for Version 3    		
+   			final File fMainXsd3 = new File(getClass().getResource("schema/main/issue_175_main_v3.xsd").getFile());
+   			final File fImportXsd3 = new File(getClass().getResource("schema/import/issue_175_import_v2.xsd").getFile());
+   			    		
+   			final Map<String, Source> schemas_Ver3 = new HashMap<>();
+   	    	schemas_Ver3.put("http://www.example.org/issue_175_main", new StreamSource(fMainXsd3));
+   	    	schemas_Ver3.put("http://www.example.org/issue_175_import", new StreamSource(fImportXsd3));
+   			        	
+   			final XMLValidationSchema valSchemaVal_Ver3 = sf.createSchema(null, schemas_Ver3, new EntityResolver() {
+   				@Override
+   				public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException 
+   				{							
+   		        	System.out.println("ResolveEntity() - Public id: [" + publicId + "], System id: [" + systemId + "]");
+   		        	
+   		        	InputSource is = null;
+   		        	
+   		        	File tmp = new File(URI.create(systemId).getPath());
+   		        	
+   		        	String fileName = tmp.getName();
+   		        	if ("issue_175_import.xsd".equalsIgnoreCase(fileName))
+   		        	{
+   		        		tmp = fImportXsd3;
+   		        	}
+   		        	
+   		        	try
+   		        	{
+   		        		is = new InputSource(new FileReader(tmp));
+   		        		is.setSystemId(tmp.toURI().toString());
+   		        	}
+   		        	catch (IOException ex)
+   	    			{
+   	    				ex.printStackTrace();
+   	    			}
+   		        	
+   		        	System.out.println("ResolveEntity() - System Id: [" + is.getSystemId() + "]");
+   		        	
+   					return is;
+   				}				
+   			});   			
+   			
+        	try
+        	{
+        		// Xsd Validation - Version 1 XML data	        	
+	    		final WstxInputFactory xf = new WstxInputFactory();
+	    		xf.configureForXmlConformance();
+					    		
+	    		final XMLStreamReader2 xmlRdr = (XMLStreamReader2) xf.createXMLStreamReader(getClass().getResourceAsStream("Issue_175_ver1.xml"), "utf-8");
+				xmlRdr.setValidationProblemHandler(new ValidationProblemHandler() 
+				{
+					@Override
+					public void reportProblem(XMLValidationProblem arg0) throws XMLValidationException 
+					{
+						if (arg0.getSeverity() == XMLValidationProblem.SEVERITY_WARNING )
+						{
+							System.out.println("Validation Warning: " + arg0.getMessage());
+						}
+						else
+						{
+							System.out.println("Validation Error: " + arg0.getMessage());	
+							throw arg0.toException();
+						}
+					}			
+				});		
+			
+				// Validate
+				xmlRdr.validateAgainst(valSchemaVal_Ver1);
+	
+				// Run thru each element, etc.
+				while(xmlRdr.hasNext())	{ xmlRdr.next(); }
+			}
+			catch (Exception ex)
+			{
+				ex.printStackTrace();
+				Assert.fail("Unexpected error: " + ex.toString());
+			}
+				
+	   		try 
+			{
+	   			// Xsd Validation - Version 2 XML data   					
+	    		final WstxInputFactory xf = new WstxInputFactory();
+	    		xf.configureForXmlConformance();
+	   			
+	    		final XMLStreamReader2 xmlRdr = (XMLStreamReader2) xf.createXMLStreamReader(getClass().getResourceAsStream("Issue_175_ver2.xml"), "utf-8");
+				xmlRdr.setValidationProblemHandler(new ValidationProblemHandler() 
+				{
+					@Override
+					public void reportProblem(XMLValidationProblem arg0) throws XMLValidationException 
+					{
+						if (arg0.getSeverity() == XMLValidationProblem.SEVERITY_WARNING )
+						{
+							System.out.println("Validation Warning: " + arg0.getMessage());
+						}
+						else
+						{
+							System.out.println("Validation Error: " + arg0.getMessage());	
+							throw arg0.toException();
+						}
+					}			
+				});		
+			
+				// Validate
+				xmlRdr.validateAgainst(valSchemaVal_Ver2);
+	
+				// Run thru each element, etc.
+				while(xmlRdr.hasNext())	{ xmlRdr.next(); }
+			}
+			catch (Exception ex)
+			{
+				ex.printStackTrace();
+				Assert.fail("Unexpected error: " + ex.toString());
+			}				
+		
+	 		try 
+			{
+	   			// Xsd Validation - Version 3 XML data
+	 			final WstxInputFactory xf = new WstxInputFactory();
+	    		xf.configureForXmlConformance();
+	    		
+	    		XMLStreamReader2 xmlRdr = (XMLStreamReader2) xf.createXMLStreamReader(getClass().getResourceAsStream("Issue_175_ver3.xml"), "utf-8");
+				xmlRdr.setValidationProblemHandler(new ValidationProblemHandler() 
+				{
+					@Override
+					public void reportProblem(XMLValidationProblem arg0) throws XMLValidationException 
+					{
+						if (arg0.getSeverity() == XMLValidationProblem.SEVERITY_WARNING )
+						{
+							System.out.println("Validation Warning: " + arg0.getMessage());
+						}
+						else
+						{
+							System.out.println("Validation Error: " + arg0.getMessage());	
+							throw arg0.toException();
+						}
+					}			
+				});		
+			
+				// Validate
+				xmlRdr.validateAgainst(valSchemaVal_Ver3);
+	
+				// Run thru each element, etc.
+				while(xmlRdr.hasNext())	{ xmlRdr.next(); }
+			}
+			catch (Exception ex)
+			{
+				ex.printStackTrace();
+				Assert.fail("Unexpected error: " + ex.toString());
+			}       	
+		}
+		catch (Exception ex)
+		{
+			ex.printStackTrace();
+			Assert.fail("Unexpected error: " + ex.toString());
+		}   	
+	}	
+	
+	@Test
+	/**
+	 *  This tests in the case where the XML version does not match the schema version, this validates the correct XSDs 
+	 *  are being picked up.
+	 */	
+	public void testValidationOfWrongXmlVersionWithEntityResolver() 
+	{
+		try 
+		{
+			// Build Schema Validation object for Version 1
+    		File fMainXsd1 = new File(getClass().getResource("schema/main/issue_175_main_v1.xsd").getFile());
+    		final File fImportXsd1 = new File(getClass().getResource("schema/import/issue_175_import_v1.xsd").getFile());
+    		
+    		// Test to make sure we picked up the XSD
+    		Assert.assertTrue(fMainXsd1.exists());
+    		Assert.assertTrue(fImportXsd1.exists());
+    		
+        	final Map<String, Source> schemas_Ver1 = new HashMap<>();
+        	schemas_Ver1.put("http://www.example.org/issue_175_main", new StreamSource(fMainXsd1));
+        	schemas_Ver1.put("http://www.example.org/issue_175_import", new StreamSource(fImportXsd1));
+        	
+    		final W3CMultiSchemaFactory sf = new W3CMultiSchemaFactory();
+        	sf.setEntityResolver(new EntityResolver() {
+    			@Override
+    			public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException 
+    			{							
+    	        	System.out.println("ResolveEntity() - Public id: [" + publicId + "], System id: [" + systemId + "]");
+    	        	
+    	        	InputSource is = null;
+    	        	
+    	        	File tmp = new File(URI.create(systemId).getPath());
+    	        	
+    	        	String fileName = tmp.getName();
+    	        	if ("issue_175_import.xsd".equalsIgnoreCase(fileName))
+    	        	{
+    	        		tmp = fImportXsd1;
+    	        	}
+    	        	
+    	        	try
+    	        	{
+    	        		is = new InputSource(new FileReader(tmp));
+    	        		is.setSystemId(tmp.toURI().toString());
+    	        	}
+    	        	catch (IOException ex)
+        			{
+        				ex.printStackTrace();
+        			}
+    	        	
+    	        	System.out.println("ResolveEntity() - System Id: [" + is.getSystemId() + "]");
+    	        	
+    				return is;
+    			}				
+    		});
+        	
+        	final XMLValidationSchema valSchemaVal_Ver1 = sf.createSchema(null, schemas_Ver1);
+        	    		
+   	  		// Build Schema Validation object for Version 2    		
+   			final File fMainXsd2 = new File(getClass().getResource("schema/main/issue_175_main_v2.xsd").getFile());
+   			final File fImportXsd2 = new File(getClass().getResource("schema/import/issue_175_import_v1.xsd").getFile());
+   			    		
+   			final Map<String, Source> schemas_Ver2 = new HashMap<>();
+   	    	schemas_Ver2.put("http://www.example.org/issue_175_main", new StreamSource(fMainXsd2));
+   	    	schemas_Ver2.put("http://www.example.org/issue_175_import", new StreamSource(fImportXsd2));
+   			        	
+   			final XMLValidationSchema valSchemaVal_Ver2 = sf.createSchema(null, schemas_Ver2, new EntityResolver() {
+   				@Override
+   				public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException 
+   				{							
+   		        	System.out.println("ResolveEntity() - Public id: [" + publicId + "], System id: [" + systemId + "]");
+   		        	
+   		        	InputSource is = null;
+   		        	
+   		        	File tmp = new File(URI.create(systemId).getPath());
+   		        	
+   		        	String fileName = tmp.getName();
+   		        	if ("issue_175_import.xsd".equalsIgnoreCase(fileName))
+   		        	{
+   		        		tmp = fImportXsd2;
+   		        	}
+   		        	
+   		        	try
+   		        	{
+   		        		is = new InputSource(new FileReader(tmp));
+   		        		is.setSystemId(tmp.toURI().toString());
+   		        	}
+   		        	catch (IOException ex)
+   	    			{
+   	    				ex.printStackTrace();
+   	    			}
+   		        	
+   		        	System.out.println("ResolveEntity() - System Id: [" + is.getSystemId() + "]");
+   		        	
+   					return is;
+   				}				
+   			});
+        	
+   			// Build Schema Validation object for Version 3    		
+   			final File fMainXsd3 = new File(getClass().getResource("schema/main/issue_175_main_v3.xsd").getFile());
+   			final File fImportXsd3 = new File(getClass().getResource("schema/import/issue_175_import_v2.xsd").getFile());
+   			    		
+   			final Map<String, Source> schemas_Ver3 = new HashMap<>();
+   	    	schemas_Ver3.put("http://www.example.org/issue_175_main", new StreamSource(fMainXsd3));
+   	    	schemas_Ver3.put("http://www.example.org/issue_175_import", new StreamSource(fImportXsd3));
+   			        	
+   			final XMLValidationSchema valSchemaVal_Ver3 = sf.createSchema(null, schemas_Ver3, new EntityResolver() {
+   				@Override
+   				public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException 
+   				{							
+   		        	System.out.println("ResolveEntity() - Public id: [" + publicId + "], System id: [" + systemId + "]");
+   		        	
+   		        	InputSource is = null;
+   		        	
+   		        	File tmp = new File(URI.create(systemId).getPath());
+   		        	
+   		        	String fileName = tmp.getName();
+   		        	if ("issue_175_import.xsd".equalsIgnoreCase(fileName))
+   		        	{
+   		        		tmp = fImportXsd3;
+   		        	}
+   		        	
+   		        	try
+   		        	{
+   		        		is = new InputSource(new FileReader(tmp));
+   		        		is.setSystemId(tmp.toURI().toString());
+   		        	}
+   		        	catch (IOException ex)
+   	    			{
+   	    				ex.printStackTrace();
+   	    			}
+   		        	
+   		        	System.out.println("ResolveEntity() - System Id: [" + is.getSystemId() + "]");
+   		        	
+   					return is;
+   				}				
+   			});   			
+   			
+        	try
+        	{
+        		// Xsd Validation - Version 1 Schema, Version 2 XML data	        	
+	    		final WstxInputFactory xf = new WstxInputFactory();
+	    		xf.configureForXmlConformance();
+					    		
+	    		final XMLStreamReader2 xmlRdr = (XMLStreamReader2) xf.createXMLStreamReader(getClass().getResourceAsStream("Issue_175_ver2.xml"), "utf-8");
+				xmlRdr.setValidationProblemHandler(new ValidationProblemHandler() 
+				{
+					@Override
+					public void reportProblem(XMLValidationProblem arg0) throws XMLValidationException 
+					{
+						if (arg0.getSeverity() == XMLValidationProblem.SEVERITY_WARNING )
+						{
+							System.out.println("Validation Warning: " + arg0.getMessage());
+						}
+						else
+						{
+							System.out.println("Validation Error: " + arg0.getMessage());	
+							throw arg0.toException();
+						}
+					}			
+				});		
+			
+				// Validate
+				xmlRdr.validateAgainst(valSchemaVal_Ver1);
+	
+				// Run thru each element, etc.
+				while(xmlRdr.hasNext())	{ xmlRdr.next(); }
+				
+				Assert.fail("Error expected");
+			}
+			catch (Exception ex)
+			{
+				//ex.printStackTrace();
+				Assert.assertEquals("ParseError at [row,col]:[12,3]\n"
+						+ "Message: element \"Element5\" was found where no element may occur", ex.getMessage());
+			}
+				
+	   		try 
+			{
+	   			// Xsd Validation - Version 2 Schema, Version 3 XML data   					
+	    		final WstxInputFactory xf = new WstxInputFactory();
+	    		xf.configureForXmlConformance();
+	   			
+	    		final XMLStreamReader2 xmlRdr = (XMLStreamReader2) xf.createXMLStreamReader(getClass().getResourceAsStream("Issue_175_ver3.xml"), "utf-8");
+				xmlRdr.setValidationProblemHandler(new ValidationProblemHandler() 
+				{
+					@Override
+					public void reportProblem(XMLValidationProblem arg0) throws XMLValidationException 
+					{
+						if (arg0.getSeverity() == XMLValidationProblem.SEVERITY_WARNING )
+						{
+							System.out.println("Validation Warning: " + arg0.getMessage());
+						}
+						else
+						{
+							System.out.println("Validation Error: " + arg0.getMessage());	
+							throw arg0.toException();
+						}
+					}			
+				});		
+			
+				// Validate
+				xmlRdr.validateAgainst(valSchemaVal_Ver2);
+	
+				// Run thru each element, etc.
+				while(xmlRdr.hasNext())	{ xmlRdr.next(); }
+				
+				Assert.fail("Error expected");
+			}
+			catch (Exception ex)
+			{
+				//ex.printStackTrace();
+				Assert.assertEquals("ParseError at [row,col]:[6,2]\n"
+						+ "Message: unexpected attribute \"Attrib4\"", ex.getMessage());
+			}				
+		
+	 		try 
+			{
+	   			// Xsd Validation - Version 3 Schema, Version 1 XML data
+	 			final WstxInputFactory xf = new WstxInputFactory();
+	    		xf.configureForXmlConformance();
+	    		
+	    		XMLStreamReader2 xmlRdr = (XMLStreamReader2) xf.createXMLStreamReader(getClass().getResourceAsStream("Issue_175_ver1.xml"), "utf-8");
+				xmlRdr.setValidationProblemHandler(new ValidationProblemHandler() 
+				{
+					@Override
+					public void reportProblem(XMLValidationProblem arg0) throws XMLValidationException 
+					{
+						if (arg0.getSeverity() == XMLValidationProblem.SEVERITY_WARNING )
+						{
+							System.out.println("Validation Warning: " + arg0.getMessage());
+						}
+						else
+						{
+							System.out.println("Validation Error: " + arg0.getMessage());	
+							throw arg0.toException();
+						}
+					}			
+				});		
+			
+				// Validate
+				xmlRdr.validateAgainst(valSchemaVal_Ver3);
+	
+				// Run thru each element, etc.
+				while(xmlRdr.hasNext())	{ xmlRdr.next(); }
+				
+				Assert.fail("Error expected");
+			}
+			catch (Exception ex)
+			{
+				//ex.printStackTrace();
+				Assert.assertEquals("ParseError at [row,col]:[6,2]\n"
+						+ "Message: element \"Data\" is missing \"Attrib4\" attribute", ex.getMessage());
+			}       	
+		}
+		catch (Exception ex)
+		{
+			ex.printStackTrace();
+			Assert.fail("Unexpected error: " + ex.toString());
+		}   	
+	}			
+}

--- a/src/test/java/wstxtest/stream/TestComments.java
+++ b/src/test/java/wstxtest/stream/TestComments.java
@@ -31,6 +31,7 @@ public class TestComments
     /**
      * Method called via input config iterator, with all possible
      * configurations
+     *  - Added additional comment formats for issue [ WSTX-67 ]
      */
     @Override
     public void runTest(XMLInputFactory f, InputConfigIterator it)
@@ -42,6 +43,12 @@ public class TestComments
             +"<!-- Longer comment that contains quite a bit of content\n"
             +" so that we can check boundary - conditions too... -->"
             +"<!----><!-- and entities: &amp; &#12;&#x1d; -->\n"
+            +"<!--\n"
+            +"Comment spanning mulitple lines with no spaces\n"
+            +"-->\n"
+            +"<!-- \n"
+            +"  Comment spanning mulitple lines with spaces \n"
+            +" -->\n"            
             +"</root>";
         XMLStreamReader sr = constructStreamReader(f, XML);
         streamAndCheck(sr, it, XML, XML, false);
@@ -49,6 +56,6 @@ public class TestComments
         sr = constructStreamReader(f, XML);
         streamAndCheck(sr, it, XML, XML, true);
     }
-
+    
 }
 

--- a/src/test/java/wstxtest/stream/TestLocation.java
+++ b/src/test/java/wstxtest/stream/TestLocation.java
@@ -1,6 +1,8 @@
 package wstxtest.stream;
 
 import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import javax.xml.stream.*;
 
@@ -153,7 +155,7 @@ public class TestLocation
         doTestOffset(true, false); // coalesce
         doTestOffset(true, true); // coalesce
     }
-
+   
     /*
     /////////////////////////////////////////////////////////
     // Helper methods:
@@ -199,4 +201,123 @@ public class TestLocation
             }
         }
     }
+    
+    /**
+     * This test was added due to bug [WSTX-67]: Wrong line number for XML event 
+     * location in elements following comment with no spaces, split across 
+     * multiple lines.
+     */
+    public void testLocationAfterComment()
+    	throws XMLStreamException
+    {
+       String input1 = "<?xml version=\"1.0\"?>\n" +
+    	        "<!DOCTYPE menu [\n" +
+    	        "<!--\n" +
+    	        "Some comment with no spaces\n" +
+    	        "-->\n" +
+    	        "<!ELEMENT menu (modulo)* >\n" +
+    	        "]>\n" +
+    	        "<menu value=\"foo\"></menu>";
+       
+       String input2 = "<?xml version=\"1.0\"?>\n" +
+   	        "<!DOCTYPE menu [\n" +
+   	        "<!-- \n" +
+   	        "  Some comment with spaces\n" +
+   	        " -->\n" +
+   	        "<!ELEMENT menu (modulo)* >\n" +
+   	        "]>\n" +
+   	        "<menu value=\"foo\"></menu>";
+       
+       List<String> lstLineData = doTestCommentLocation(input1, false);
+       
+       assertEquals(5, lstLineData.size());
+       assertEquals("[7 - START_DOCUMENT] {L=1;C=1;O=0;}", lstLineData.get(0));
+       assertEquals("[11 - DTD] {L=2;C=1;O=22;}", lstLineData.get(1));
+       assertEquals("[1 - START_ELEMENT] {L=8;C=1;O=106;}", lstLineData.get(2));
+       assertEquals("[2 - END_ELEMENT] {L=8;C=19;O=124;}", lstLineData.get(3));
+       assertEquals("[8 - END_DOCUMENT] {L=8;C=26;O=131;}", lstLineData.get(4));
+
+       lstLineData = doTestCommentLocation(input1, true);
+       
+       assertEquals(5, lstLineData.size());
+       assertEquals("[7 - START_DOCUMENT] {L=1;C=1;O=0;}", lstLineData.get(0));
+       assertEquals("[11 - DTD] {L=2;C=1;O=22;}", lstLineData.get(1));
+       assertEquals("[1 - START_ELEMENT] {L=8;C=1;O=106;}", lstLineData.get(2));
+       assertEquals("[2 - END_ELEMENT] {L=8;C=19;O=124;}", lstLineData.get(3));
+       assertEquals("[8 - END_DOCUMENT] {L=8;C=26;O=131;}", lstLineData.get(4));
+       
+       lstLineData = doTestCommentLocation(input2, false);
+       
+       assertEquals(5, lstLineData.size());
+       assertEquals("[7 - START_DOCUMENT] {L=1;C=1;O=0;}", lstLineData.get(0));
+       assertEquals("[11 - DTD] {L=2;C=1;O=22;}", lstLineData.get(1));
+       assertEquals("[1 - START_ELEMENT] {L=8;C=1;O=107;}", lstLineData.get(2));
+       assertEquals("[2 - END_ELEMENT] {L=8;C=19;O=125;}", lstLineData.get(3));
+       assertEquals("[8 - END_DOCUMENT] {L=8;C=26;O=132;}", lstLineData.get(4));
+       
+       lstLineData = doTestCommentLocation(input2, true);
+       
+       assertEquals(5, lstLineData.size());
+       assertEquals("[7 - START_DOCUMENT] {L=1;C=1;O=0;}", lstLineData.get(0));
+       assertEquals("[11 - DTD] {L=2;C=1;O=22;}", lstLineData.get(1));
+       assertEquals("[1 - START_ELEMENT] {L=8;C=1;O=107;}", lstLineData.get(2));
+       assertEquals("[2 - END_ELEMENT] {L=8;C=19;O=125;}", lstLineData.get(3));
+       assertEquals("[8 - END_DOCUMENT] {L=8;C=26;O=132;}", lstLineData.get(4));
+    }
+    
+    public List<String> doTestCommentLocation(String input, boolean supportDtd)
+            throws XMLStreamException
+    {
+    	List<String> lstLineData = new ArrayList<>();
+    	Reader reader = new StringReader(input);
+
+        // Force woodstox factory instance
+        XMLInputFactory f = new com.ctc.wstx.stax.WstxInputFactory();
+
+        f.setProperty(XMLInputFactory.SUPPORT_DTD, supportDtd);
+        f.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+        f.setProperty(XMLInputFactory.IS_VALIDATING, false);
+        // Should shrink it to get faster convergence
+        XMLStreamReader rdr = f.createXMLStreamReader(reader);
+        
+        lstLineData.add(getLocation(rdr));
+        while (rdr.hasNext()) {
+          rdr.next();
+          lstLineData.add(getLocation(rdr));
+        }
+     
+        return lstLineData;
+    }
+    
+    private String getLocation(XMLStreamReader xmlReader)
+    {    	
+    	int eventType = xmlReader.getEventType();
+    	StringBuilder sb = new StringBuilder();
+    	sb.append("[").append(eventType).append(" - ");
+    	
+        switch (eventType) {
+        case XMLStreamReader.ENTITY_REFERENCE: sb.append("ENTITY_REFERENCE"); break;
+        case XMLStreamReader.COMMENT: sb.append("COMMENT"); break;
+        case XMLStreamReader.PROCESSING_INSTRUCTION: sb.append("PROCESSING_INSTRUCTION"); break;
+        case XMLStreamReader.CHARACTERS: sb.append("CHARACTERS"); break;
+        case XMLStreamReader.START_ELEMENT: sb.append("START_ELEMENT"); break;
+        case XMLStreamConstants.END_ELEMENT: sb.append("END_ELEMENT"); break;
+        case XMLStreamConstants.CDATA: sb.append("CDATA"); break;
+        case XMLStreamConstants.DTD: sb.append("DTD"); break;
+        case XMLStreamReader.END_DOCUMENT: sb.append("END_DOCUMENT"); break;
+        case XMLStreamReader.START_DOCUMENT: sb.append("START_DOCUMENT"); break;
+        default: sb.append("unknown (" + eventType + ")"); break;
+        }
+        sb.append("] {");
+        
+        Location loc = xmlReader.getLocation();
+        sb.append("L=").append(loc.getLineNumber()).append(";");
+        sb.append("C=").append(loc.getColumnNumber()).append(";");
+        sb.append("O=").append(loc.getCharacterOffset()).append(";");
+        sb.append("}");
+        
+        //System.out.println(sb.toString());
+        
+        return sb.toString();
+      }
 }

--- a/src/test/resources/wstxtest/msv/schema/import/issue_175_import_v1.xsd
+++ b/src/test/resources/wstxtest/msv/schema/import/issue_175_import_v1.xsd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+		xmlns:imprt="http://www.example.org/issue_175_import"
+		targetNamespace="http://www.example.org/issue_175_import" 
+	    xmlns:tns="http://www.example.org/issue_175_import" 
+	    elementFormDefault="qualified"
+	    version="1">
+	    	    
+	<xsd:attribute name="XmlVersion">
+	  <xsd:simpleType>
+	  	<xsd:restriction base="xsd:string">
+	  		<xsd:pattern value="[0-9]{1}" />
+	  	</xsd:restriction>
+	  </xsd:simpleType>
+	</xsd:attribute>
+		    
+	<xsd:attributeGroup name="AttribGroup">
+		<xsd:attribute ref="imprt:Attrib1" use="required" />
+		<xsd:attribute ref="imprt:Attrib2" use="required" />				
+	</xsd:attributeGroup>
+	
+	<xsd:attribute name="Attrib1" type="xsd:string" />
+	<xsd:attribute name="Attrib2" type="xsd:string" />	
+	
+	<xsd:attribute name="Attrib3" type="xsd:boolean"/>
+</xsd:schema>

--- a/src/test/resources/wstxtest/msv/schema/import/issue_175_import_v2.xsd
+++ b/src/test/resources/wstxtest/msv/schema/import/issue_175_import_v2.xsd
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+		xmlns:imprt="http://www.example.org/issue_175_import"
+		targetNamespace="http://www.example.org/issue_175_import" 
+	    xmlns:tns="http://www.example.org/issue_175_import" 
+	    elementFormDefault="qualified"
+	    version="2">
+	    	    
+	<xsd:attribute name="XmlVersion">
+	  <xsd:simpleType>
+	  	<xsd:restriction base="xsd:string">
+	  		<xsd:pattern value="[0-9]{1}" />
+	  	</xsd:restriction>
+	  </xsd:simpleType>
+	</xsd:attribute>
+		    
+	<xsd:attributeGroup name="AttribGroup">
+		<xsd:attribute ref="imprt:Attrib1" use="required" />
+		<xsd:attribute ref="imprt:Attrib2" use="required" />		
+		<xsd:attribute ref="imprt:Attrib4" use="required" />
+	</xsd:attributeGroup>
+	
+	<xsd:attribute name="Attrib1" type="xsd:string" />
+	<xsd:attribute name="Attrib2" type="xsd:string" />		
+	<xsd:attribute name="Attrib3" type="xsd:boolean"/>
+	<xsd:attribute name="Attrib4" type="xsd:boolean"/>
+	<xsd:attribute name="Attrib5" type="xsd:string"/>	
+</xsd:schema>

--- a/src/test/resources/wstxtest/msv/schema/main/issue_175_main_v1.xsd
+++ b/src/test/resources/wstxtest/msv/schema/main/issue_175_main_v1.xsd
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema 
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+	xmlns:xhtml="http://www.w3.org/1999/xhtml"
+	xmlns:main="http://www.example.org/issue_175_main"
+	xmlns:imprt="http://www.example.org/issue_175_import"		
+	targetNamespace="http://www.example.org/issue_175_main" 
+	xmlns:tns="http://www.example.org/issue_175_main" 
+	elementFormDefault="qualified"
+	attributeFormDefault="unqualified"
+	version="1">
+	
+	<xsd:import namespace="http://www.example.org/issue_175_import" schemaLocation="issue_175_import.xsd"/>
+	
+	<xsd:element name="Issue175" type="main:Issue175Type">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:h1>Schema definition for Issue #175 (issue_175_main.xsd)</xhtml:h1>
+			</xsd:documentation>
+			<xsd:documentation>
+				<xhtml:p></xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+		
+	<xsd:complexType name="Issue175Type">
+		<xsd:sequence>
+			<xsd:element ref="main:Data" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute ref="main:XmlVersion" use="required"/>
+		<xsd:attribute ref="imprt:XmlVersion" use="required"/>
+	</xsd:complexType>
+
+	<xsd:attribute name="XmlVersion">
+	  <xsd:simpleType>
+	  	<xsd:restriction base="xsd:string">
+	  		<xsd:pattern value="[0-9]{1}" />
+	  	</xsd:restriction>
+	  </xsd:simpleType>
+	</xsd:attribute>
+
+	<xsd:element name="Data" type="main:DataType">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Main element in the XML</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="DataType">
+		<xsd:sequence>
+			<xsd:element ref="main:Element1" />
+			<xsd:element ref="main:Element2" />
+			<xsd:element ref="main:Element3" />
+			<xsd:element ref="main:Element4" />
+		</xsd:sequence>
+		<xsd:attributeGroup ref="imprt:AttribGroup" />		
+	</xsd:complexType>
+	
+	<xsd:element name="Element1" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>First data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:element name="Element2" type="xsd:decimal">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Second data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:element name="Element3" type="main:Element3Type">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Third data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+		
+	</xsd:element>
+
+	<xsd:complexType name="Element3Type">
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string">
+				<xsd:attribute ref="imprt:Attrib3"/>	
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+
+	<xsd:element name="Element4" type="main:Element4Type">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Fourth data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:simpleType name="Element4Type">
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="ENUM1" />
+			<xsd:enumeration value="ENUM2" />
+			<xsd:enumeration value="ENUM3" />
+			<xsd:enumeration value="ENUM4" />
+		</xsd:restriction>
+	</xsd:simpleType>
+</xsd:schema>

--- a/src/test/resources/wstxtest/msv/schema/main/issue_175_main_v2.xsd
+++ b/src/test/resources/wstxtest/msv/schema/main/issue_175_main_v2.xsd
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema 
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+	xmlns:xhtml="http://www.w3.org/1999/xhtml"
+	xmlns:main="http://www.example.org/issue_175_main"
+	xmlns:imprt="http://www.example.org/issue_175_import"		
+	targetNamespace="http://www.example.org/issue_175_main" 
+	xmlns:tns="http://www.example.org/issue_175_main" 
+	elementFormDefault="qualified"
+	attributeFormDefault="unqualified"
+	version="2">
+	
+	<xsd:import namespace="http://www.example.org/issue_175_import" schemaLocation="issue_175_import.xsd"/>
+	
+	<xsd:element name="Issue175" type="main:Issue175Type">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:h1>Schema definition for Issue #175 (issue_175_main.xsd)</xhtml:h1>
+			</xsd:documentation>
+			<xsd:documentation>
+				<xhtml:p></xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+		
+	<xsd:complexType name="Issue175Type">
+		<xsd:sequence>
+			<xsd:element ref="main:Data" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute ref="main:XmlVersion" use="required"/>
+		<xsd:attribute ref="imprt:XmlVersion" use="required"/>
+	</xsd:complexType>
+
+	<xsd:attribute name="XmlVersion">
+	  <xsd:simpleType>
+	  	<xsd:restriction base="xsd:string">
+	  		<xsd:pattern value="[0-9]{1}" />
+	  	</xsd:restriction>
+	  </xsd:simpleType>
+	</xsd:attribute>
+
+	<xsd:element name="Data" type="main:DataType">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Main element in the XML</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="DataType">
+		<xsd:sequence>
+			<xsd:element ref="main:Element1" />
+			<xsd:element ref="main:Element2" />
+			<xsd:element ref="main:Element3" />
+			<xsd:element ref="main:Element4" />
+			<xsd:element ref="main:Element5" />
+		</xsd:sequence>
+		<xsd:attributeGroup ref="imprt:AttribGroup" />		
+	</xsd:complexType>
+	
+	<xsd:element name="Element1" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>First data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:element name="Element2" type="xsd:decimal">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Second data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:element name="Element3" type="main:Element3Type">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Third data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+		
+	</xsd:element>
+
+	<xsd:complexType name="Element3Type">
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string">
+				<xsd:attribute ref="imprt:Attrib3"/>	
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+
+	<xsd:element name="Element4" type="main:Element4Type">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Fourth data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:simpleType name="Element4Type">
+		<xsd:restriction base="xsd:NMTOKEN">
+			<xsd:enumeration value="ENUM1" />
+			<xsd:enumeration value="ENUM2" />
+			<xsd:enumeration value="ENUM3" />
+			<xsd:enumeration value="ENUM4" />
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:element name="Element5" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Fifth data element (v2.0)</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>	
+</xsd:schema>

--- a/src/test/resources/wstxtest/msv/schema/main/issue_175_main_v3.xsd
+++ b/src/test/resources/wstxtest/msv/schema/main/issue_175_main_v3.xsd
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema 
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+	xmlns:xhtml="http://www.w3.org/1999/xhtml"
+	xmlns:main="http://www.example.org/issue_175_main"
+	xmlns:imprt="http://www.example.org/issue_175_import"		
+	targetNamespace="http://www.example.org/issue_175_main" 
+	xmlns:tns="http://www.example.org/issue_175_main" 
+	elementFormDefault="qualified"
+	attributeFormDefault="unqualified"
+	version="3">
+	
+	<xsd:import namespace="http://www.example.org/issue_175_import" schemaLocation="issue_175_import.xsd"/>
+	
+	<xsd:element name="Issue175" type="main:Issue175Type">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:h1>Schema definition for Issue #175 (issue_175_main.xsd)</xhtml:h1>
+			</xsd:documentation>
+			<xsd:documentation>
+				<xhtml:p></xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+		
+	<xsd:complexType name="Issue175Type">
+		<xsd:sequence>
+			<xsd:element ref="main:Data" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute ref="main:XmlVersion" use="required"/>
+		<xsd:attribute ref="imprt:XmlVersion" use="required"/>
+	</xsd:complexType>
+
+	<xsd:attribute name="XmlVersion">
+	  <xsd:simpleType>
+	  	<xsd:restriction base="xsd:string">
+	  		<xsd:pattern value="[0-9]{1}" />
+	  	</xsd:restriction>
+	  </xsd:simpleType>
+	</xsd:attribute>
+
+	<xsd:element name="Data" type="main:DataType">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Main element in the XML</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+
+	<xsd:complexType name="DataType">
+		<xsd:sequence>
+			<xsd:element ref="main:Element1" />
+			<xsd:element ref="main:Element2" />
+			<xsd:element ref="main:Element3" />
+			<xsd:element ref="main:Element4" />
+			<xsd:element ref="main:Element5" />
+		</xsd:sequence>
+		<xsd:attributeGroup ref="imprt:AttribGroup" />		
+	</xsd:complexType>
+	
+	<xsd:element name="Element1" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>First data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:element name="Element2" type="xsd:decimal">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Second data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:element name="Element3" type="main:Element3Type">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Third data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+		
+	</xsd:element>
+
+	<xsd:complexType name="Element3Type">
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:string">
+				<xsd:attribute ref="imprt:Attrib3"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	
+	<xsd:element name="Element4" type="main:Element4Type">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Fourth data element</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	
+	<xsd:complexType name="Element4Type">
+		<xsd:simpleContent>
+			<xsd:extension base="main:ENUM_VAL">
+				<xsd:attribute ref="imprt:Attrib5"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="ENUM_VAL">
+			<xsd:restriction base="xsd:NMTOKEN">
+				<xsd:enumeration value="ENUM1" />
+				<xsd:enumeration value="ENUM2" />
+				<xsd:enumeration value="ENUM3" />
+				<xsd:enumeration value="ENUM4" />
+			</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:element name="Element5" type="xsd:string">
+		<xsd:annotation>
+			<xsd:documentation>
+				<xhtml:p>Fifth data element (v2.0)</xhtml:p>
+			</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>	
+</xsd:schema>


### PR DESCRIPTION
- Skipping over the carriage return without incrementing line number, now calling skipCRLF() function to properly increment.
- Added additional comment testing coverage, src/test/java/wstxtest/stream/TestComments.java
- Extended JUnit test per issue writeup, src/test/java/wstxtest/stream/TestLocation.java