### PR TITLE
Changes / fixes for Issue #67

### DIFF
--- a/src/main/java/com/ctc/wstx/dtd/MinimalDTDReader.java
+++ b/src/main/java/com/ctc/wstx/dtd/MinimalDTDReader.java
@@ -320,6 +320,7 @@ public class MinimalDTDReader
                 if (c == '-') {
                     return;
                 }
+                if (c == '\n') skipCRLF(c);
             } else if (c == '\n' || c == '\r') {
                 skipCRLF(c);
             }

--- a/src/main/java/com/ctc/wstx/dtd/MinimalDTDReader.java
+++ b/src/main/java/com/ctc/wstx/dtd/MinimalDTDReader.java
@@ -320,8 +320,8 @@ public class MinimalDTDReader
                 if (c == '-') {
                     return;
                 }
-                if (c == '\n') skipCRLF(c);
-            } else if (c == '\n' || c == '\r') {
+            }
+            if (c == '\n' || c == '\r') {
                 skipCRLF(c);
             }
         }

--- a/src/test/java/wstxtest/stream/TestComments.java
+++ b/src/test/java/wstxtest/stream/TestComments.java
@@ -31,6 +31,7 @@ public class TestComments
     /**
      * Method called via input config iterator, with all possible
      * configurations
+     *  - Added additional comment formats for issue [ WSTX-67 ]
      */
     @Override
     public void runTest(XMLInputFactory f, InputConfigIterator it)
@@ -42,6 +43,12 @@ public class TestComments
             +"<!-- Longer comment that contains quite a bit of content\n"
             +" so that we can check boundary - conditions too... -->"
             +"<!----><!-- and entities: &amp; &#12;&#x1d; -->\n"
+            +"<!--\n"
+            +"Comment spanning mulitple lines with no spaces\n"
+            +"-->\n"
+            +"<!-- \n"
+            +"  Comment spanning mulitple lines with spaces \n"
+            +" -->\n"            
             +"</root>";
         XMLStreamReader sr = constructStreamReader(f, XML);
         streamAndCheck(sr, it, XML, XML, false);
@@ -49,6 +56,6 @@ public class TestComments
         sr = constructStreamReader(f, XML);
         streamAndCheck(sr, it, XML, XML, true);
     }
-
+    
 }
 


### PR DESCRIPTION
Wrong line for XML event location in elements following DTD
- Added additional comment coverage in TestComments.java
- Added test per Issue #67 writeup to TestLocation.java
- Carriage line was not being checked so it was skipped, added check and call to skipCRLF(c) to advance line number.
