### PR TITLE
Disable resolveEntityRefs by default for SAX parsers

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -114,3 +114,5 @@ Philipp Nanz (@philippn)
 
 * Contributed #209: SAXParser: Add support for `LexicalHandler.startEntity()` and `.endEntity()`
  (7.1.0)
+* Contributed #211: Disable `resolveEntityReferences` by default for newly created SAX parsers
+ (7.1.0)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -8,6 +8,8 @@ Project: woodstox
 
 #209: SAXParser: Add support for `LexicalHandler.startEntity()` and `.endEntity()`
  (contributed by Philipp N)
+#211: Disable `resolveEntityReferences` by default for newly created SAX parsers
+ (contributed by Philipp N)
 
 7.0.0 (21-Jun-2024)
 

--- a/src/main/java/com/ctc/wstx/sax/WstxSAXParserFactory.java
+++ b/src/main/java/com/ctc/wstx/sax/WstxSAXParserFactory.java
@@ -50,6 +50,9 @@ public class WstxSAXParserFactory
     public WstxSAXParserFactory()
     {
         this(new WstxInputFactory());
+        // 27-Aug-2024, philippn: For SAX parsing, we will usually want startEntity and endEntity events,
+        // thus we disable replaceEntityRefs by default (as per [woodstox-core#211])
+        mStaxFactory.getConfig().doReplaceEntityRefs(false);
     }
 
     /**

--- a/src/test/java/wstxtest/sax/TestLexicalHandler.java
+++ b/src/test/java/wstxtest/sax/TestLexicalHandler.java
@@ -11,6 +11,7 @@ import org.xml.sax.ext.DefaultHandler2;
 import wstxtest.BaseWstxTest;
 
 import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 import java.net.URL;
 
 /**
@@ -19,7 +20,8 @@ import java.net.URL;
 public class TestLexicalHandler extends BaseWstxTest {
 
     public void testReplaceEntityRefs() throws Exception {
-        WstxSAXParserFactory spf = new WstxSAXParserFactory();
+        WstxInputFactory staxFactory = new WstxInputFactory();
+        SAXParserFactory spf = new WstxSAXParserFactory(staxFactory);
         SAXParser sp = spf.newSAXParser();
         EventListener listener = Mockito.mock(EventListener.class);
         sp.parse(getInputSource("eyephone.xml"), new EventListenerHandler(listener));
@@ -31,9 +33,7 @@ public class TestLexicalHandler extends BaseWstxTest {
     }
 
     public void testWithoutReplaceEntityRefs() throws Exception {
-        WstxInputFactory staxFactory = new WstxInputFactory();
-        staxFactory.getConfig().doReplaceEntityRefs(false);
-        WstxSAXParserFactory spf = new WstxSAXParserFactory(staxFactory);
+        SAXParserFactory spf = new WstxSAXParserFactory();
         SAXParser sp = spf.newSAXParser();
         EventListener listener = Mockito.mock(EventListener.class);
         sp.parse(getInputSource("eyephone.xml"), new EventListenerHandler(listener));
@@ -47,9 +47,7 @@ public class TestLexicalHandler extends BaseWstxTest {
     }
 
     public void testWithoutReplaceEntityRefsAndWithLexicalHandler() throws Exception {
-        WstxInputFactory staxFactory = new WstxInputFactory();
-        staxFactory.getConfig().doReplaceEntityRefs(false);
-        WstxSAXParserFactory spf = new WstxSAXParserFactory(staxFactory);
+        SAXParserFactory spf = new WstxSAXParserFactory();
         SAXParser sp = spf.newSAXParser();
         EventListener listener = Mockito.mock(EventListener.class);
         sp.setProperty("http://xml.org/sax/properties/lexical-handler", new EventListenerHandler(listener));


### PR DESCRIPTION
Hi Tatu,

this is the PR for #211 . I'm looking forward for your feedback :-)

Thanks and kind regards,
Philipp