### PR TITLE
Fix Locator not being fully initialized when setLocator is called

### DIFF
--- a/src/main/java/com/ctc/wstx/sax/WstxSAXParser.java
+++ b/src/main/java/com/ctc/wstx/sax/WstxSAXParser.java
@@ -579,11 +579,6 @@ public class WstxSAXParser
             }
         }
 
-        if (mContentHandler != null) {
-            mContentHandler.setDocumentLocator(this);
-            mContentHandler.startDocument();
-        }
-
         // Note: since we are reusing the same config instance, need to
         // make sure state is not carried forward. Thus:
         cfg.resetState();
@@ -619,6 +614,12 @@ public class WstxSAXParser
             mStandalone = mScanner.standaloneSet();
             mAttrCollector = mScanner.getAttributeCollector();
             mElemStack = mScanner.getInputElementStack();
+
+            if (mContentHandler != null) {
+                mContentHandler.setDocumentLocator(this);
+                mContentHandler.startDocument();
+            }
+
             fireEvents();
         } catch (Exception e) {
             throwSaxException(e);

--- a/src/test/java/wstxtest/sax/TestBasicSax.java
+++ b/src/test/java/wstxtest/sax/TestBasicSax.java
@@ -23,6 +23,7 @@ public class TestBasicSax
         +"<!DOCTYPE root []>"
         +"<root><!-- comment -->"
         +"<leaf attr='a&amp;b!'>rock&apos;n <![CDATA[roll]]></leaf><?proc instr?></root>  ";
+    final static String DOCUMENT_SYSTEMID = "document.xml";
 
     public void testSimpleNs()
         throws Exception
@@ -89,8 +90,10 @@ public class TestBasicSax
         } else {
             src = new InputSource(new ByteArrayInputStream(XML.getBytes("UTF-8")));
         }
+        src.setSystemId(DOCUMENT_SYSTEMID);
 
         sp.parse(src, h);
+        assertEquals(DOCUMENT_SYSTEMID, h._systemId);
         assertEquals(2, h._elems);
         assertEquals(1, h._attrs);
         assertEquals(11, h._charCount);
@@ -111,9 +114,19 @@ public class TestBasicSax
     final static class MyHandler
         extends DefaultHandler
     {
-        public int _elems, _attrs;
+        public int _elems, _attrs, _charCount;
+        public String _systemId;
+        private Locator locator;
 
-        public int _charCount;
+        @Override
+        public void setDocumentLocator(Locator locator) {
+            this.locator = locator;
+        }
+
+        @Override
+        public void startDocument() throws SAXException {
+            _systemId = locator.getSystemId();
+        }
 
         @Override
         public void characters(char[] ch, int start, int length) {


### PR DESCRIPTION
Hello,

this is a PR for https://github.com/FasterXML/woodstox/issues/213.

It also modifies one of the SAX tests to test for systemId. The test fails with 7.1.0 and succeeds with 7.1.1-SNAPSHOT. I wasn't totally sure about the naming of the variable locator in the test though. Most of the variables are prefixed with _, I interpreted it that this might indicate public/direct use and went without it for the locator.

feel free to change anything, as you see fit.

Thanks in advance and kind regards,
Philipp