### PR TITLE
#216 Cleanup: switch to some features of modern Java in test code

### DIFF
--- a/src/test/java/failing/BasicSaxTest.java
+++ b/src/test/java/failing/BasicSaxTest.java
@@ -24,14 +24,14 @@ public class BasicSaxTest
     public void testCData() throws Exception
     {
         SAXParser parser = new WstxSAXParser();
-        StringBuffer buffer = new StringBuffer("<root><![CDATA[");
+        StringBuilder builder = new StringBuilder("<root><![CDATA[");
         for (int i=0; i<100000; i++) {
-            buffer.append('a');
+            builder.append('a');
         }
-        buffer.append("]]></root>");
+        builder.append("]]></root>");
         CDATASectionCounter handler = new CDATASectionCounter();
         parser.setProperty("http://xml.org/sax/properties/lexical-handler", handler);
-        parser.parse(new InputSource(new StringReader(buffer.toString())), handler);
+        parser.parse(new InputSource(new StringReader(builder.toString())), handler);
         // Should get as many cdata sections as text segments
         int cdatas = handler.getCDATASectionCount();
         int segments = handler.getSegmentCount();

--- a/src/test/java/failing/ExtLocationInfo91Test.java
+++ b/src/test/java/failing/ExtLocationInfo91Test.java
@@ -42,16 +42,13 @@ public class ExtLocationInfo91Test
     public void testLocationsWithExtEntity()
             throws XMLStreamException
     {
-        XMLResolver resolver = new XMLResolver() {
-            @Override
-            public Object resolveEntity(String publicID, String systemID, String baseURI, String namespace) throws XMLStreamException {
-                if (INCL_URI.equals(systemID)){
-                    StreamSource src = new StreamSource(new StringReader(TEST_EXT_ENT_INCL), systemID);
-                    return src;
-                }
-                fail("Unexpected systemID to resolve: " + systemID);
-                return null;
+        XMLResolver resolver = (publicID, systemID, baseURI, namespace) -> {
+            if (INCL_URI.equals(systemID)){
+                StreamSource src = new StreamSource(new StringReader(TEST_EXT_ENT_INCL), systemID);
+                return src;
             }
+            fail("Unexpected systemID to resolve: " + systemID);
+            return null;
         };
         XMLStreamReader2 sr = getReader(TEST_EXT_ENT, URI, resolver);
 

--- a/src/test/java/failing/RelaxNGTest.java
+++ b/src/test/java/failing/RelaxNGTest.java
@@ -112,7 +112,7 @@ public class RelaxNGTest
 	      } catch (XMLValidationException vex) {
 	          String origMsg = vex.getMessage();
 	          String msg = (origMsg == null) ? "" : origMsg.toLowerCase();
-	          if (msg.indexOf(failPhrase.toLowerCase()) < 0) {
+	          if (!msg.contains(failPhrase.toLowerCase())) {
 			String actualMsg = "Expected validation exception for "+failMsg+", containing phrase '"+failPhrase+"': got '"+origMsg+"'";
 			if (strict) {
 			    fail(actualMsg);

--- a/src/test/java/failing/TestInvalidAttributeValue190.java
+++ b/src/test/java/failing/TestInvalidAttributeValue190.java
@@ -40,16 +40,10 @@ public class TestInvalidAttributeValue190
         XMLStreamReader2 sr = (XMLStreamReader2)f.createXMLStreamReader(
                 new StringReader(DOC));
 
-        final List<XMLValidationProblem> probs = new ArrayList<XMLValidationProblem>();
+        final List<XMLValidationProblem> probs = new ArrayList<>();
         
         sr.validateAgainst(schema);
-        sr.setValidationProblemHandler(new ValidationProblemHandler() {
-            @Override
-            public void reportProblem(XMLValidationProblem problem)
-                    throws XMLValidationException {
-                probs.add(problem);
-            }
-        });
+        sr.setValidationProblemHandler(probs::add);
 
         assertTokenType(START_ELEMENT, sr.next());
         assertEquals("root", sr.getLocalName());

--- a/src/test/java/failing/W3CSchemaNillable179Test.java
+++ b/src/test/java/failing/W3CSchemaNillable179Test.java
@@ -110,12 +110,8 @@ public class W3CSchemaNillable179Test
             xmlReader = (XMLStreamReader2) f.createXMLStreamReader(new StringReader(xmlDocument));
 
             if (validateReader) {
-                xmlReader.setValidationProblemHandler(new ValidationProblemHandler() {
-                    @Override
-                    public void reportProblem(XMLValidationProblem problem)
-                            throws XMLValidationException {
-                        throw new LocalValidationError(problem);
-                    }
+                xmlReader.setValidationProblemHandler(problem -> {
+                    throw new LocalValidationError(problem);
                 });
                 xmlReader.validateAgainst(schema);
             }
@@ -123,12 +119,8 @@ public class W3CSchemaNillable179Test
             xmlWriter = (XMLStreamWriter2) getOutputFactory().createXMLStreamWriter(writer);
             
             if (validateWriter) {
-                xmlWriter.setValidationProblemHandler(new ValidationProblemHandler() {
-                    @Override
-                    public void reportProblem(XMLValidationProblem problem)
-                            throws XMLValidationException {
-                        throw new LocalValidationError(problem);
-                    }
+                xmlWriter.setValidationProblemHandler(problem -> {
+                    throw new LocalValidationError(problem);
                 });
                 xmlWriter.validateAgainst(schema);
             }

--- a/src/test/java/org/codehaus/stax/test/BaseStaxTest.java
+++ b/src/test/java/org/codehaus/stax/test/BaseStaxTest.java
@@ -34,22 +34,22 @@ public abstract class BaseStaxTest
      */
     final static String PROP_REPORT_CDATA = "http://java.sun.com/xml/stream/properties/report-cdata-event";
 
-    final static HashMap<Integer,String> mTokenTypes = new HashMap<Integer,String>();
+    final static HashMap<Integer,String> mTokenTypes = new HashMap<>();
     static {
-        mTokenTypes.put(Integer.valueOf(START_ELEMENT), "START_ELEMENT");
-        mTokenTypes.put(Integer.valueOf(END_ELEMENT), "END_ELEMENT");
-        mTokenTypes.put(Integer.valueOf(START_DOCUMENT), "START_DOCUMENT");
-        mTokenTypes.put(Integer.valueOf(END_DOCUMENT), "END_DOCUMENT");
-        mTokenTypes.put(Integer.valueOf(CHARACTERS), "CHARACTERS");
-        mTokenTypes.put(Integer.valueOf(CDATA), "CDATA");
-        mTokenTypes.put(Integer.valueOf(COMMENT), "COMMENT");
-        mTokenTypes.put(Integer.valueOf(PROCESSING_INSTRUCTION), "PROCESSING_INSTRUCTION");
-        mTokenTypes.put(Integer.valueOf(DTD), "DTD");
-        mTokenTypes.put(Integer.valueOf(SPACE), "SPACE");
-        mTokenTypes.put(Integer.valueOf(ENTITY_REFERENCE), "ENTITY_REFERENCE");
-        mTokenTypes.put(Integer.valueOf(NAMESPACE), "NAMESPACE_DECLARATION");
-        mTokenTypes.put(Integer.valueOf(NOTATION_DECLARATION), "NOTATION_DECLARATION");
-        mTokenTypes.put(Integer.valueOf(ENTITY_DECLARATION), "ENTITY_DECLARATION");
+        mTokenTypes.put(START_ELEMENT, "START_ELEMENT");
+        mTokenTypes.put(END_ELEMENT, "END_ELEMENT");
+        mTokenTypes.put(START_DOCUMENT, "START_DOCUMENT");
+        mTokenTypes.put(END_DOCUMENT, "END_DOCUMENT");
+        mTokenTypes.put(CHARACTERS, "CHARACTERS");
+        mTokenTypes.put(CDATA, "CDATA");
+        mTokenTypes.put(COMMENT, "COMMENT");
+        mTokenTypes.put(PROCESSING_INSTRUCTION, "PROCESSING_INSTRUCTION");
+        mTokenTypes.put(DTD, "DTD");
+        mTokenTypes.put(SPACE, "SPACE");
+        mTokenTypes.put(ENTITY_REFERENCE, "ENTITY_REFERENCE");
+        mTokenTypes.put(NAMESPACE, "NAMESPACE_DECLARATION");
+        mTokenTypes.put(NOTATION_DECLARATION, "NOTATION_DECLARATION");
+        mTokenTypes.put(ENTITY_DECLARATION, "ENTITY_DECLARATION");
     }
 
     /*
@@ -185,7 +185,7 @@ public abstract class BaseStaxTest
     protected static boolean isCoalescing(XMLInputFactory f)
         throws XMLStreamException
     {
-        return ((Boolean) f.getProperty(XMLInputFactory.IS_COALESCING)).booleanValue();
+        return (Boolean) f.getProperty(XMLInputFactory.IS_COALESCING);
     }
 
     protected static void setCoalescing(XMLInputFactory f, boolean state)
@@ -200,7 +200,7 @@ public abstract class BaseStaxTest
     protected static boolean isValidating(XMLInputFactory f)
         throws XMLStreamException
     {
-        return ((Boolean) f.getProperty(XMLInputFactory.IS_VALIDATING)).booleanValue();
+        return (Boolean) f.getProperty(XMLInputFactory.IS_VALIDATING);
     }
 
     protected static void setValidating(XMLInputFactory f, boolean state)
@@ -219,7 +219,7 @@ public abstract class BaseStaxTest
     protected static boolean isNamespaceAware(XMLInputFactory f)
         throws XMLStreamException
     {
-        return ((Boolean) f.getProperty(XMLInputFactory.IS_NAMESPACE_AWARE)).booleanValue();
+        return (Boolean) f.getProperty(XMLInputFactory.IS_NAMESPACE_AWARE);
     }
 
     /**
@@ -269,7 +269,7 @@ public abstract class BaseStaxTest
         try {
             f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, b);
             Object act = f.getProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES);
-            return (act instanceof Boolean) && ((Boolean) act).booleanValue() == state;
+            return (act instanceof Boolean) && (Boolean) act == state;
         } catch (IllegalArgumentException e) {
             /* Let's assume, then, that the property (or specific value for it)
              * is NOT supported...
@@ -360,7 +360,7 @@ public abstract class BaseStaxTest
     protected static String getAllText(XMLStreamReader sr)
         throws XMLStreamException
     {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (true) {
             int tt = sr.getEventType();
             if (tt != CHARACTERS && tt != SPACE && tt != CDATA) {
@@ -375,7 +375,7 @@ public abstract class BaseStaxTest
     protected static String getAllCData(XMLStreamReader sr)
         throws XMLStreamException
     {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         while (true) {
             /* Note: CDATA sections CAN be reported as CHARACTERS, but
              * not as SPACE
@@ -524,7 +524,7 @@ public abstract class BaseStaxTest
         String msg = e.getMessage();
         String lmsg = msg.toLowerCase();
         String lmatch = match.toLowerCase();
-        if (lmsg.indexOf(lmatch) < 0) {
+        if (!lmsg.contains(lmatch)) {
             fail("Expected an exception with sub-string \""+match+"\": got one with message \""+msg+"\"");
         }
     }
@@ -550,7 +550,7 @@ public abstract class BaseStaxTest
 
     protected static String tokenTypeDesc(int tt)
     {
-        String desc = (String) mTokenTypes.get(Integer.valueOf(tt));
+        String desc = (String) mTokenTypes.get(tt);
         if (desc == null) {
             return "["+tt+"]";
         }
@@ -603,7 +603,7 @@ public abstract class BaseStaxTest
             return "_";
         }
         if (ch > 127 || ch < 32) {
-            StringBuffer sb = new StringBuffer(6);
+            StringBuilder sb = new StringBuilder(6);
             sb.append("\\u");
             String hex = Integer.toHexString((int)ch);
             for (int i = 0, len = 4 - hex.length(); i < len; i++) {
@@ -622,7 +622,7 @@ public abstract class BaseStaxTest
         }
 
         int len = str.length();
-        StringBuffer sb = new StringBuffer(len + 64);
+        StringBuilder sb = new StringBuilder(len + 64);
         for (int i = 0; i < len; ++i) {
             char c = str.charAt(i);
             String res = printable(c);

--- a/src/test/java/org/codehaus/stax/test/evt/TestEventDTD.java
+++ b/src/test/java/org/codehaus/stax/test/evt/TestEventDTD.java
@@ -175,9 +175,7 @@ public class TestEventDTD
 
     private void testListElems(List<?> l, Class<?> expType)
     {
-        Iterator<?> it = l.iterator();
-        while (it.hasNext()) {
-            Object o = it.next();
+        for (Object o : l) {
             assertNotNull(o);
             assertTrue(expType.isAssignableFrom(o.getClass()));
         }

--- a/src/test/java/org/codehaus/stax/test/evt/TestEventFactory.java
+++ b/src/test/java/org/codehaus/stax/test/evt/TestEventFactory.java
@@ -294,7 +294,7 @@ public class TestEventFactory
         final String NS_URI = "http://foo";
 
         XMLEventFactory f = getEventFactory();
-        ArrayList<Attribute> attrs = new ArrayList<Attribute>();
+        ArrayList<Attribute> attrs = new ArrayList<>();
         Attribute attr1 = f.createAttribute(new QName("attr1"), "value");
         testEventWritability(attr1);
         attrs.add(attr1);

--- a/src/test/java/org/codehaus/stax/test/evt/TestEventWriter.java
+++ b/src/test/java/org/codehaus/stax/test/evt/TestEventWriter.java
@@ -24,10 +24,10 @@ public class TestEventWriter
 
         XMLEventFactory evtf = getEventFactory();
 
-        ArrayList<Attribute> attrs = new ArrayList<Attribute>();
+        ArrayList<Attribute> attrs = new ArrayList<>();
         attrs.add(evtf.createAttribute("attr", "value"));
         attrs.add(evtf.createAttribute("ns", "uri", "attr2", "value2"));
-        ArrayList<Namespace> ns = new ArrayList<Namespace>();
+        ArrayList<Namespace> ns = new ArrayList<>();
         ns.add(evtf.createNamespace("ns", "uri"));
         StartElement elem = evtf.createStartElement("", "", "root", attrs.iterator(), ns.iterator());
         
@@ -137,7 +137,7 @@ public class TestEventWriter
 
     private <T> List<T> fetchElems(Iterator<T> it)
     {
-        ArrayList<T> l = new ArrayList<T>();
+        ArrayList<T> l = new ArrayList<>();
         while (it.hasNext()) {
             l.add(it.next());
         }
@@ -178,7 +178,7 @@ public class TestEventWriter
     private List<XMLEvent> collectEvents(XMLEventReader er)
         throws XMLStreamException
     {
-        ArrayList<XMLEvent> events = new ArrayList<XMLEvent>();
+        ArrayList<XMLEvent> events = new ArrayList<>();
         while (er.hasNext()) {
             events.add(er.nextEvent());
         }

--- a/src/test/java/org/codehaus/stax/test/evt/TestStartElem.java
+++ b/src/test/java/org/codehaus/stax/test/evt/TestStartElem.java
@@ -306,7 +306,7 @@ public class TestStartElem
 
     private String get11AttrDoc()
     {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("<root");
         for (int i = 0; i < ATTR11_NAMES.length; ++i) {
             sb.append(' ');

--- a/src/test/java/org/codehaus/stax/test/stream/TestAttributeRead.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestAttributeRead.java
@@ -476,7 +476,7 @@ public class TestAttributeRead
 
     private String get11AttrDoc()
     {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("<root");
         for (int i = 0; i < ATTR11_NAMES.length; ++i) {
             sb.append(' ');

--- a/src/test/java/org/codehaus/stax/test/stream/TestCDataRead.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestCDataRead.java
@@ -14,8 +14,8 @@ public class TestCDataRead
     final static String CDATA1;
     final static String CDATA2;
     static {
-        StringBuffer sb1 = new StringBuffer(8000);
-        StringBuffer sb2 = new StringBuffer(8000);
+        StringBuilder sb1 = new StringBuilder(8000);
+        StringBuilder sb2 = new StringBuilder(8000);
 
         sb1.append("...");
         sb2.append("\n \n\n ");
@@ -92,7 +92,7 @@ public class TestCDataRead
                          CDATA, type);
         }
 
-        StringBuffer sb = new StringBuffer(16000);
+        StringBuilder sb = new StringBuilder(16000);
         do {
             sb.append(getAndVerifyText(sr));
             type = sr.next();
@@ -144,7 +144,7 @@ public class TestCDataRead
             XMLStreamReader sr = getReader(XML, coal);
             assertTokenType(START_ELEMENT, sr.next());
             // Ok, now should get an exception...
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             int type = -1;
             try {
                 while (true) {

--- a/src/test/java/org/codehaus/stax/test/stream/TestCommentRead.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestCommentRead.java
@@ -212,11 +212,11 @@ public class TestCommentRead
                     break;
                 case 4:
                     method = "getNamespaceCount";
-                    result = Integer.valueOf(sr.getNamespaceCount());
+                    result = sr.getNamespaceCount();
                     break;
                 case 5:
                     method = "getAttributeCount";
-                    result = Integer.valueOf(sr.getAttributeCount());
+                    result = sr.getAttributeCount();
                     break;
                 case 6:
                     method = "getPITarget";

--- a/src/test/java/org/codehaus/stax/test/stream/TestDoctypeDecl.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestDoctypeDecl.java
@@ -210,11 +210,11 @@ public class TestDoctypeDecl
                     break;
                 case 4:
                     method = "getNamespaceCount";
-                    result = Integer.valueOf(sr.getNamespaceCount());
+                    result = sr.getNamespaceCount();
                     break;
                 case 5:
                     method = "getAttributeCount";
-                    result = Integer.valueOf(sr.getAttributeCount());
+                    result = sr.getAttributeCount();
                     break;
                 case 6:
                     method = "getPITarget";
@@ -230,11 +230,11 @@ public class TestDoctypeDecl
                     break;
                 case 9:
                     method = "getTextStart";
-                    result = Integer.valueOf(sr.getTextStart());
+                    result = sr.getTextStart();
                     break;
                 case 10:
                     method = "getTextLength";
-                    result = Integer.valueOf(sr.getTextLength());
+                    result = sr.getTextLength();
                     break;
                 }
                 fail("Expected IllegalStateException, when calling "

--- a/src/test/java/org/codehaus/stax/test/stream/TestEntityRead.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestEntityRead.java
@@ -37,7 +37,7 @@ public class TestEntityRead
         assertTokenType(CHARACTERS, sr.next());
 
         // Let's not count on coalescing working, though...
-        StringBuffer sb = new StringBuffer(getAndVerifyText(sr));
+        StringBuilder sb = new StringBuilder(getAndVerifyText(sr));
         int type;
 
         while ((type = sr.next()) == CHARACTERS) {
@@ -61,7 +61,7 @@ public class TestEntityRead
         assertTokenType(START_ELEMENT, sr.next());
         assertTokenType(CHARACTERS, sr.next());
         // may still be split, though (buggy coalescing)
-        StringBuffer sb = new StringBuffer(getAndVerifyText(sr));
+        StringBuilder sb = new StringBuilder(getAndVerifyText(sr));
         int type;
 
         while ((type = sr.next()) == CHARACTERS) {
@@ -85,7 +85,7 @@ public class TestEntityRead
     public void testValidSurrogatePairEntities()
             throws XMLStreamException
     {
-        final Map<String, String> xmlWithExp = new HashMap<String, String>();
+        final Map<String, String> xmlWithExp = new HashMap<>();
         // Numeric surrogate pairs
         xmlWithExp.put("<root>surrogate pair: &#55356;&#57221;.</root>",
                 "surrogate pair: \uD83C\uDF85.");
@@ -110,7 +110,7 @@ public class TestEntityRead
             assertTokenType(START_ELEMENT, sr.next());
             assertTokenType(CHARACTERS, sr.next());
             
-            StringBuffer sb = new StringBuffer(getAndVerifyText(sr));
+            StringBuilder sb = new StringBuilder(getAndVerifyText(sr));
             int type;
 
             while ((type = sr.next()) == CHARACTERS) {
@@ -665,11 +665,11 @@ public class TestEntityRead
                     break;
                 case 3:
                     method = "getNamespaceCount";
-                    result = Integer.valueOf(sr.getNamespaceCount());
+                    result = sr.getNamespaceCount();
                     break;
                 case 4:
                     method = "getAttributeCount";
-                    result = Integer.valueOf(sr.getAttributeCount());
+                    result = sr.getAttributeCount();
                     break;
                 case 5:
                     method = "getPITarget";
@@ -685,11 +685,11 @@ public class TestEntityRead
                     break;
                 case 8:
                     method = "getTextStart";
-                    result = Integer.valueOf(sr.getTextStart());
+                    result = sr.getTextStart();
                     break;
                 case 9:
                     method = "getTextLength";
-                    result = Integer.valueOf(sr.getTextLength());
+                    result = sr.getTextLength();
                     break;
                 }
                 fail("Expected IllegalArgumentException, when calling "

--- a/src/test/java/org/codehaus/stax/test/stream/TestFilteredReader.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestFilteredReader.java
@@ -66,13 +66,8 @@ public class TestFilteredReader
 
     private StreamFilter getElementFilter(final String localName)
     {
-        return new StreamFilter() {
-            @Override
-            public boolean accept(XMLStreamReader r) {
-                    return r.getEventType() == XMLStreamConstants.START_ELEMENT &&
-                        r.getLocalName().equals(localName);
-                }
-            };
+        return r -> r.getEventType() == XMLStreamConstants.START_ELEMENT &&
+            r.getLocalName().equals(localName);
     }
     
     private XMLStreamReader createFilteredReader(StreamFilter filter, String content,

--- a/src/test/java/org/codehaus/stax/test/stream/TestGetSegmentedText.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestGetSegmentedText.java
@@ -67,7 +67,7 @@ public class TestGetSegmentedText
         /* Ok... let's just access all the text, by one char reads, from
          * possibly multiple events:
          */
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
           while (type == CHARACTERS) {
             char[] buf = new char[5];
             int offset = 0;
@@ -161,7 +161,7 @@ public class TestGetSegmentedText
                 assertTokenType(START_ELEMENT, sr.next());
                 int segCount = 0;
                 int totalLen = sExpResult.length();
-                StringBuffer totalBuf = new StringBuffer(totalLen);
+                StringBuilder totalBuf = new StringBuilder(totalLen);
 
                 /* Ok; for each segment let's test separately first,
                  * and then combine all the results together as well
@@ -175,7 +175,7 @@ public class TestGetSegmentedText
                     if (coalescing && segCount > 1) {
                         fail("Didn't expect multiple CHARACTERS segments when coalescing: first segment contained "+segOffset+" chars from the whole expected "+totalLen+" chars");
                     }
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     int count;
                     int offset = 0;
                     int readCount = 0;
@@ -254,7 +254,7 @@ public class TestGetSegmentedText
     private void initData()
         throws XMLStreamException
     {
-        StringBuffer sb = new StringBuffer("<?xml version='1.0'?>");
+        StringBuilder sb = new StringBuilder("<?xml version='1.0'?>");
         sb.append("<root>");
         
         /* Let's create a ~64kchar text segment for testing, first; and one
@@ -273,7 +273,7 @@ public class TestGetSegmentedText
         XMLInputFactory f = getFactory(true, false, true);
         XMLStreamReader sr = constructStreamReader(f, XML);
         assertTokenType(START_ELEMENT, sr.next());
-        StringBuffer sb2 = new StringBuffer(XML.length());
+        StringBuilder sb2 = new StringBuilder(XML.length());
         while (sr.next() == CHARACTERS) {
             sb2.append(sr.getText());
         }

--- a/src/test/java/org/codehaus/stax/test/stream/TestMisc.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestMisc.java
@@ -164,8 +164,8 @@ public class TestMisc
 
         for (int i = 0; i < lengths.length; ++i) {
             int len = lengths[i];
-            StringBuffer input = new StringBuffer(len * 3 / 2);
-            StringBuffer output = new StringBuffer(len + 100);
+            StringBuilder input = new StringBuilder(len * 3 / 2);
+            StringBuilder output = new StringBuilder(len + 100);
 
             Random r = new Random(i);
 

--- a/src/test/java/org/codehaus/stax/test/stream/TestProcInstrRead.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestProcInstrRead.java
@@ -217,11 +217,11 @@ public class TestProcInstrRead
                     break;
                 case 4:
                     method = "getNamespaceCount";
-                    result = Integer.valueOf(sr.getNamespaceCount());
+                    result = sr.getNamespaceCount();
                     break;
                 case 5:
                     method = "getAttributeCount";
-                    result = Integer.valueOf(sr.getAttributeCount());
+                    result = sr.getAttributeCount();
                     break;
                 case 6:
                     method = "getText";
@@ -233,11 +233,11 @@ public class TestProcInstrRead
                     break;
                 case 8:
                     method = "getTextStart";
-                    result = Integer.valueOf(sr.getTextStart());
+                    result = sr.getTextStart();
                     break;
                 case 9:
                     method = "getTextLength";
-                    result = Integer.valueOf(sr.getTextLength());
+                    result = sr.getTextLength();
                     break;
                 }
                 fail("Expected IllegalStateException, when calling "

--- a/src/test/java/org/codehaus/stax/test/stream/TestRandomStream.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestRandomStream.java
@@ -146,7 +146,7 @@ public class TestRandomStream
         }
         assertEquals(START_ELEMENT, type);
         
-        StringBuffer act = new StringBuffer(1000);
+        StringBuilder act = new StringBuilder(1000);
 
         do {
             if (type == START_ELEMENT || type == END_ELEMENT) {

--- a/src/test/java/org/codehaus/stax/test/stream/TestTextCoalescing.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestTextCoalescing.java
@@ -84,7 +84,7 @@ public class TestTextCoalescing
          */
         // Now, we may get more than one CHARACTERS
         int count = 1;
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append('[');
         sb.append(sr.getText());
         sb.append(']');
@@ -143,7 +143,7 @@ public class TestTextCoalescing
     {
         assertTokenType(expType, sr.getEventType());
         //if (expType != sr.getEventType()) System.err.println("WARN: expected "+tokenTypeDesc(expType)+", got "+tokenTypeDesc(sr.getEventType()));
-        StringBuffer sb = new StringBuffer(getAndVerifyText(sr));
+        StringBuilder sb = new StringBuilder(getAndVerifyText(sr));
         int count = 1;
         while ((sr.next()) == expType) {
             ++count;

--- a/src/test/java/org/codehaus/stax/test/stream/TestXmlDecl.java
+++ b/src/test/java/org/codehaus/stax/test/stream/TestXmlDecl.java
@@ -139,11 +139,11 @@ public class TestXmlDecl
                     break;
                 case 4:
                     method = "getNamespaceCount";
-                    result = Integer.valueOf(sr.getNamespaceCount());
+                    result = sr.getNamespaceCount();
                     break;
                 case 5:
                     method = "getAttributeCount";
-                    result = Integer.valueOf(sr.getAttributeCount());
+                    result = sr.getAttributeCount();
                     break;
                 case 6:
                     method = "getPITarget";

--- a/src/test/java/org/codehaus/stax/test/vstream/TestAttrTypes.java
+++ b/src/test/java/org/codehaus/stax/test/vstream/TestAttrTypes.java
@@ -44,7 +44,7 @@ public class TestAttrTypes
         int count = sr.getAttributeCount();
         assertEquals(7, count);
 
-        HashMap<String,String> seen = new HashMap<String,String>();
+        HashMap<String,String> seen = new HashMap<>();
         for (int i = 0; i < count; ++i) {
             String name = sr.getAttributeLocalName(i);
             String value = sr.getAttributeValue(i);

--- a/src/test/java/org/codehaus/stax/test/vstream/TestParamEntities.java
+++ b/src/test/java/org/codehaus/stax/test/vstream/TestParamEntities.java
@@ -20,7 +20,7 @@ public class TestParamEntities
     public void testExternalParamDeclViaPE()
         throws XMLStreamException
     {
-        HashMap<String,String> m = new HashMap<String,String>();
+        HashMap<String,String> m = new HashMap<>();
         m.put("ent1", "<!ELEMENT doc EMPTY>\n"
             +"<!ENTITY % e SYSTEM 'ent2'>\n"
               +"<!ATTLIST doc a1 CDATA %e; 'v1'>");

--- a/src/test/java/stax2/BaseStax2Test.java
+++ b/src/test/java/stax2/BaseStax2Test.java
@@ -41,19 +41,19 @@ public abstract class BaseStax2Test
      */
     final static String ATTR_NO_PREFIX = "";
 
-    final static HashMap<Integer,String> mTokenTypes = new HashMap<Integer,String>();
+    final static HashMap<Integer,String> mTokenTypes = new HashMap<>();
     static {
-        mTokenTypes.put(Integer.valueOf(START_ELEMENT), "START_ELEMENT");
-        mTokenTypes.put(Integer.valueOf(END_ELEMENT), "END_ELEMENT");
-        mTokenTypes.put(Integer.valueOf(START_DOCUMENT), "START_DOCUMENT");
-        mTokenTypes.put(Integer.valueOf(END_DOCUMENT), "END_DOCUMENT");
-        mTokenTypes.put(Integer.valueOf(CHARACTERS), "CHARACTERS");
-        mTokenTypes.put(Integer.valueOf(CDATA), "CDATA");
-        mTokenTypes.put(Integer.valueOf(COMMENT), "COMMENT");
-        mTokenTypes.put(Integer.valueOf(PROCESSING_INSTRUCTION), "PROCESSING_INSTRUCTION");
-        mTokenTypes.put(Integer.valueOf(DTD), "DTD");
-        mTokenTypes.put(Integer.valueOf(SPACE), "SPACE");
-        mTokenTypes.put(Integer.valueOf(ENTITY_REFERENCE), "ENTITY_REFERENCE");
+        mTokenTypes.put(START_ELEMENT, "START_ELEMENT");
+        mTokenTypes.put(END_ELEMENT, "END_ELEMENT");
+        mTokenTypes.put(START_DOCUMENT, "START_DOCUMENT");
+        mTokenTypes.put(END_DOCUMENT, "END_DOCUMENT");
+        mTokenTypes.put(CHARACTERS, "CHARACTERS");
+        mTokenTypes.put(CDATA, "CDATA");
+        mTokenTypes.put(COMMENT, "COMMENT");
+        mTokenTypes.put(PROCESSING_INSTRUCTION, "PROCESSING_INSTRUCTION");
+        mTokenTypes.put(DTD, "DTD");
+        mTokenTypes.put(SPACE, "SPACE");
+        mTokenTypes.put(ENTITY_REFERENCE, "ENTITY_REFERENCE");
     }
 
     /**
@@ -239,26 +239,26 @@ public abstract class BaseStax2Test
     protected static boolean isNamespaceAware(XMLInputFactory f)
         throws XMLStreamException
     {
-        return ((Boolean) f.getProperty(XMLInputFactory.IS_NAMESPACE_AWARE)).booleanValue();
+        return (Boolean) f.getProperty(XMLInputFactory.IS_NAMESPACE_AWARE);
     }
 
     protected static void setCoalescing(XMLInputFactory f, boolean state)
         throws XMLStreamException
     {
-        f.setProperty(XMLInputFactory.IS_COALESCING, Boolean.valueOf(state));
+        f.setProperty(XMLInputFactory.IS_COALESCING, state);
     }
 
     protected static void setValidating(XMLInputFactory f, boolean state)
         throws XMLStreamException
     {
-        f.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.valueOf(state));
+        f.setProperty(XMLInputFactory.IS_VALIDATING, state);
     }
 
     protected static boolean setSupportDTD(XMLInputFactory f, boolean state)
         throws XMLStreamException
     {
         try {
-            f.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.valueOf(state));
+            f.setProperty(XMLInputFactory.SUPPORT_DTD, state);
             return (willSupportDTD(f) == state);
         } catch (IllegalArgumentException e) {
             // Let's assume that the property (or specific value) is NOT supported...
@@ -269,7 +269,7 @@ public abstract class BaseStax2Test
     protected static boolean willSupportDTD(XMLInputFactory f)
         throws XMLStreamException
     {
-        return ((Boolean) f.getProperty(XMLInputFactory.SUPPORT_DTD)).booleanValue();
+        return (Boolean) f.getProperty(XMLInputFactory.SUPPORT_DTD);
     }
 
     protected static void setReplaceEntities(XMLInputFactory f, boolean state)
@@ -301,8 +301,7 @@ public abstract class BaseStax2Test
 
     protected static void setRepairing(XMLOutputFactory f, boolean state)
     {
-        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
-                      Boolean.valueOf(state));
+        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, state);
     }
 
     protected static boolean setNamespaceAware(XMLOutputFactory f, boolean state)
@@ -325,7 +324,7 @@ public abstract class BaseStax2Test
     protected static boolean isNamespaceAware(XMLOutputFactory f)
         throws XMLStreamException
     {
-        return ((Boolean) f.getProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE)).booleanValue();
+        return (Boolean) f.getProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE);
     }
 
     /*
@@ -430,8 +429,8 @@ public abstract class BaseStax2Test
 
     protected static String tokenTypeDesc(int tt)
     {
-	String desc = mTokenTypes.get(Integer.valueOf(tt));
-	return (desc == null) ? ("["+tt+"]") : desc;
+	    String desc = mTokenTypes.get(tt);
+	    return (desc == null) ? ("["+tt+"]") : desc;
     }
 
     protected static void assertTokenType(int expType, XMLEvent evt)
@@ -589,7 +588,7 @@ public abstract class BaseStax2Test
         String msg = e.getMessage();
         String lmsg = msg.toLowerCase();
         String lmatch = match.toLowerCase();
-        if (lmsg.indexOf(lmatch) < 0) {
+        if (!lmsg.contains(lmatch)) {
             fail("Expected an exception with sub-string \""+match+"\": got one with message \""+msg+"\"");
         }
     }
@@ -597,14 +596,8 @@ public abstract class BaseStax2Test
     protected static void validateWriter(final String DOC, final List<XMLValidationProblem> probs, XMLInputFactory f,
             XMLValidationSchema schema, StringWriter writer, XMLStreamWriter2 sw) throws XMLStreamException {
         sw.validateAgainst(schema);
-        final List<XMLValidationProblem> writerProbs = new ArrayList<XMLValidationProblem>();
-        sw.setValidationProblemHandler(new ValidationProblemHandler() {
-            
-            @Override
-            public void reportProblem(XMLValidationProblem problem) throws XMLValidationException {
-                writerProbs.add(problem);
-            }
-        });
+        final List<XMLValidationProblem> writerProbs = new ArrayList<>();
+        sw.setValidationProblemHandler(writerProbs::add);
         
         XMLStreamReader2 sr = (XMLStreamReader2)f.createXMLStreamReader(
                 new StringReader(DOC));
@@ -654,7 +647,7 @@ public abstract class BaseStax2Test
             return "_";
         }
         if (ch > 127 || ch < 32) {
-            StringBuffer sb = new StringBuffer(6);
+            StringBuilder sb = new StringBuilder(6);
             sb.append("\\u");
             String hex = Integer.toHexString(ch);
             for (int i = 0, len = 4 - hex.length(); i < len; i++) {
@@ -678,7 +671,7 @@ public abstract class BaseStax2Test
             return "\\t";
         }
         if (ch > 127 || ch < 32) {
-            StringBuffer sb = new StringBuffer(6);
+            StringBuilder sb = new StringBuilder(6);
             sb.append("\\u");
             String hex = Integer.toHexString(ch);
             for (int i = 0, len = 4 - hex.length(); i < len; i++) {
@@ -697,7 +690,7 @@ public abstract class BaseStax2Test
         }
 
         int len = str.length();
-        StringBuffer sb = new StringBuffer(len + 64);
+        StringBuilder sb = new StringBuilder(len + 64);
         for (int i = 0; i < len; ++i) {
             char c = str.charAt(i);
             String res = printable(c);
@@ -717,7 +710,7 @@ public abstract class BaseStax2Test
         }
 
         int len = str.length();
-        StringBuffer sb = new StringBuffer(len + 64);
+        StringBuilder sb = new StringBuilder(len + 64);
         for (int i = 0; i < len; ++i) {
             char c = str.charAt(i);
             String res = printableWithSpaces(c);

--- a/src/test/java/stax2/evt/TestStartElementEvent.java
+++ b/src/test/java/stax2/evt/TestStartElementEvent.java
@@ -28,7 +28,7 @@ public class TestStartElementEvent
             +"</a>";
         XMLEventReader er = XML_F.createXMLEventReader(new StringReader(DOC));
 
-        ArrayList<StartElement> elemEvents = new ArrayList<StartElement>();
+        ArrayList<StartElement> elemEvents = new ArrayList<>();
 
         assertTokenType(START_DOCUMENT, er.nextEvent());
         XMLEvent evt = er.nextEvent();
@@ -97,7 +97,7 @@ public class TestStartElementEvent
         Iterator<?> it = start.getAttributes();
         @SuppressWarnings("unused")
         int count = 0;
-        Map<QName,String> attrs = new HashMap<QName,String>();
+        Map<QName,String> attrs = new HashMap<>();
 
         // First, collect the attributes
         while (it.hasNext()) {
@@ -109,11 +109,7 @@ public class TestStartElementEvent
         assertEquals(expCount, attrs.size());
 
         // Then verify we can access them ok
-        //for (Map.Entry<QName,String> en : attrs) {
-
-        Iterator<Map.Entry<QName,String>> it2 = attrs.entrySet().iterator();
-        while (it2.hasNext()) {
-            Map.Entry<QName,String> en = it2.next();
+        for (Map.Entry<QName,String> en : attrs.entrySet()) {
             QName key = en.getKey();
             String value = en.getValue();
 

--- a/src/test/java/stax2/stream/TestAttrBasic.java
+++ b/src/test/java/stax2/stream/TestAttrBasic.java
@@ -11,8 +11,8 @@ public class TestAttrBasic
         throws XMLStreamException
     {
         String[] LFs = new String[] { "\n", "\r", "\r\n" };
-        for (int i = 0; i < LFs.length; ++i) {
-            XMLStreamReader sr = constructNsStreamReader("<root attr='"+LFs[i]+"' />", true);
+        for (String lf : LFs) {
+            XMLStreamReader sr = constructNsStreamReader("<root attr='"+lf+"' />", true);
             assertTokenType(START_DOCUMENT, sr.getEventType());
             assertTokenType(START_ELEMENT, sr.next());
             assertEquals(1, sr.getAttributeCount());

--- a/src/test/java/stax2/stream/TestClosing.java
+++ b/src/test/java/stax2/stream/TestClosing.java
@@ -194,8 +194,7 @@ public class TestClosing
     XMLInputFactory2 getFactory(boolean autoClose)
     {
         XMLInputFactory2 f = getInputFactory();
-        f.setProperty(XMLInputFactory2.P_AUTO_CLOSE_INPUT,
-                      Boolean.valueOf(autoClose));
+        f.setProperty(XMLInputFactory2.P_AUTO_CLOSE_INPUT, autoClose);
         return f;
     }
 

--- a/src/test/java/stax2/stream/TestReaderConstruction.java
+++ b/src/test/java/stax2/stream/TestReaderConstruction.java
@@ -120,7 +120,7 @@ public class TestReaderConstruction
 
     String generateXML(String text)
     {
-        StringBuffer sb = new StringBuffer("<root>");
+        StringBuilder sb = new StringBuilder("<root>");
         sb.append(text);
         sb.append("</root>");
         return sb.toString();

--- a/src/test/java/stax2/stream/TestXMLStreamReader2.java
+++ b/src/test/java/stax2/stream/TestXMLStreamReader2.java
@@ -94,7 +94,7 @@ public class TestXMLStreamReader2
         XMLInputFactory2 f = getInputFactory();
         // important: don't force coalescing, that'll convert CDATA to CHARACTERS
         setCoalescing(f, false);
-        f.setProperty(XMLInputFactory2.P_REPORT_CDATA, Boolean.valueOf(report));
+        f.setProperty(XMLInputFactory2.P_REPORT_CDATA, report);
         XMLStreamReader sr = f.createXMLStreamReader(new StringReader(XML));
         if (wrapped) {
             sr = wrapWithAdapter(sr);

--- a/src/test/java/stax2/typed/ReaderArrayTestBase.java
+++ b/src/test/java/stax2/typed/ReaderArrayTestBase.java
@@ -55,8 +55,7 @@ public abstract class ReaderArrayTestBase
     private void _testSimpleIntArrayElem(boolean withNoise)
         throws XMLStreamException
     {
-        for (int i = 0; i < COUNTS_ELEM.length; ++i) {
-            int len = COUNTS_ELEM[i];
+        for (int len : COUNTS_ELEM) {
             int[] data = intArray(len);
             String XML = buildDoc(data, withNoise);
 
@@ -83,8 +82,7 @@ public abstract class ReaderArrayTestBase
     private void _testSimpleLongArrayElem(boolean withNoise)
         throws XMLStreamException
     {
-        for (int i = 0; i < COUNTS_ELEM.length; ++i) {
-            int len = COUNTS_ELEM[i];
+        for (int len : COUNTS_ELEM) {
             long[] data = longArray(len);
             String XML = buildDoc(data, withNoise);
 
@@ -111,8 +109,7 @@ public abstract class ReaderArrayTestBase
     private void _testSimpleFloatArrayElem(boolean withNoise)
         throws XMLStreamException
     {
-        for (int i = 0; i < COUNTS_ELEM.length; ++i) {
-            int len = COUNTS_ELEM[i];
+        for (int len : COUNTS_ELEM) {
             float[] data = floatArray(len);
             String XML = buildDoc(data, withNoise);
 
@@ -139,8 +136,7 @@ public abstract class ReaderArrayTestBase
     private void _testSimpleDoubleArrayElem(boolean withNoise)
         throws XMLStreamException
     {
-        for (int i = 0; i < COUNTS_ELEM.length; ++i) {
-            int len = COUNTS_ELEM[i];
+        for (int len : COUNTS_ELEM) {
             double[] data = doubleArray(len);
             String XML = buildDoc(data, withNoise);
 
@@ -249,8 +245,7 @@ public abstract class ReaderArrayTestBase
     public void testSimpleIntArrayAttr()
         throws XMLStreamException
     {
-        for (int i = 0; i < COUNTS_ATTR.length; ++i) {
-            int len = COUNTS_ATTR[i];
+        for (int len : COUNTS_ATTR) {
             int[] data = intArray(len);
             String XML = buildAttrDoc(data);
             verifyIntsAttr(XML, data);
@@ -260,8 +255,7 @@ public abstract class ReaderArrayTestBase
     public void testSimpleLongArrayAttr()
         throws XMLStreamException
     {
-        for (int i = 0; i < COUNTS_ATTR.length; ++i) {
-            int len = COUNTS_ATTR[i];
+        for (int len : COUNTS_ATTR) {
             long[] data = longArray(len);
             String XML = buildAttrDoc(data);
             verifyLongsAttr(XML, data);
@@ -271,8 +265,7 @@ public abstract class ReaderArrayTestBase
     public void testSimpleFloatArrayAttr()
         throws XMLStreamException
     {
-        for (int i = 0; i < COUNTS_ATTR.length; ++i) {
-            int len = COUNTS_ATTR[i];
+        for (int len : COUNTS_ATTR) {
             float[] data = floatArray(len);
             String XML = buildAttrDoc(data);
             verifyFloatsAttr(XML, data);
@@ -282,8 +275,7 @@ public abstract class ReaderArrayTestBase
     public void testSimpleDoubleArrayAttr()
         throws XMLStreamException
     {
-        for (int i = 0; i < COUNTS_ATTR.length; ++i) {
-            int len = COUNTS_ATTR[i];
+        for (int len : COUNTS_ATTR) {
             double[] data = doubleArray(len);
             String XML = buildAttrDoc(data);
             verifyDoublesAttr(XML, data);

--- a/src/test/java/stax2/typed/ReaderBinaryTestBase.java
+++ b/src/test/java/stax2/typed/ReaderBinaryTestBase.java
@@ -149,10 +149,8 @@ public abstract class ReaderBinaryTestBase
          */
         final int REPS = 3;
 
-        for (int bv = 0; bv < sBase64Variants.length; ++bv) {
-            Base64Variant b64variant = sBase64Variants[bv];
-            for (int x = 0; x < LEN_ELEM_MULTIPLE.length; ++x) {
-                int size = LEN_ELEM_MULTIPLE[x];
+        for (Base64Variant b64variant : sBase64Variants) {
+            for (int size : LEN_ELEM_MULTIPLE) {
                 Random r = new Random(size+1);
                 byte[][] dataTable = generateDataTable(r, size, REPS);
                 String doc = buildMultiElemDoc(b64variant, dataTable);
@@ -197,10 +195,9 @@ public abstract class ReaderBinaryTestBase
         /* 20-Nov-2008, tatus: Let's test all available base64
          *   variants too:
          */
-        for (int bv = 0; bv < sPaddingVariants.length; ++bv) {
-            Base64Variant b64variant = sPaddingVariants[bv];
-            StringBuffer b64 = new StringBuffer(data.length * 2);
-            
+        for (Base64Variant b64variant : sPaddingVariants) {
+            StringBuilder b64 = new StringBuilder(data.length * 2);
+
             /* Ok, first, let's first just generate long String of base64
              * data:
              */
@@ -223,8 +220,8 @@ public abstract class ReaderBinaryTestBase
                 _verifyElemData(sr, b64variant, r, data, byteLen, METHOD_FULL);
                 sr.close();
             }
-            
-            StringBuffer sb = new StringBuffer(b64.length() * 2);
+
+            StringBuilder sb = new StringBuilder(b64.length() * 2);
             sb.append("<root>");
             
             ptr = 0;
@@ -257,10 +254,8 @@ public abstract class ReaderBinaryTestBase
     private void _testBinaryElem(int readMethod, boolean addNoise)
         throws XMLStreamException
     {
-        for (int bv = 0; bv < sBase64Variants.length; ++bv) {
-            Base64Variant b64variant = sBase64Variants[bv];
-            for (int x = 0; x < LEN_ELEM.length; ++x) {
-                int size = LEN_ELEM[x];
+        for (Base64Variant b64variant : sBase64Variants) {
+            for (int size : LEN_ELEM) {
                 Random r = new Random(size);
                 byte[] data = generateData(r, size);
                 String doc = buildDoc(b64variant, r, data, addNoise);
@@ -386,10 +381,9 @@ public abstract class ReaderBinaryTestBase
 
         // Hmmh. Here we need to skip testing of non-padded variants...
         // (ideally would also test non-padding ones, but using different method)
-        for (int bv = 0; bv < sPaddingVariants.length; ++bv) {
-            Base64Variant b64variant = sPaddingVariants[bv];
-            for (int i = 0; i < INVALID_PADDING.length; ++i) {
-                String doc = "<root>"+INVALID_PADDING[i]+"</root>";
+        for (Base64Variant b64variant : sPaddingVariants) {
+            for (String invalidPadding : INVALID_PADDING) {
+                String doc = "<root>"+invalidPadding+"</root>";
                 XMLStreamReader2 sr = getElemReader(doc);
                 try {
                     /*int count = */ sr.readElementAsBinary(resultBuffer, 0, resultBuffer.length, b64variant);
@@ -416,10 +410,9 @@ public abstract class ReaderBinaryTestBase
         // Let's try out couple of arbitrary broken ones...
         final byte[] resultBuffer = new byte[20];
 
-        for (int bv = 0; bv < sBase64Variants.length; ++bv) {
-            Base64Variant b64variant = sBase64Variants[bv];
-            for (int i = 0; i < INVALID_WS.length; ++i) {
-                String doc = "<root>"+INVALID_WS[i]+"</root>";
+        for (Base64Variant b64variant : sBase64Variants) {
+            for (String invalidWhiteSpace : INVALID_WS) {
+                String doc = "<root>"+invalidWhiteSpace+"</root>";
                 XMLStreamReader2 sr = getElemReader(doc);
                 try {
                     /*int count = */ sr.readElementAsBinary(resultBuffer, 0, resultBuffer.length, b64variant);
@@ -437,10 +430,9 @@ public abstract class ReaderBinaryTestBase
     {
         final byte[] resultBuffer = new byte[20];
 
-        for (int bv = 0; bv < sBase64Variants.length; ++bv) {
-            Base64Variant b64variant = sBase64Variants[bv];
-            for (int i = 0; i < INVALID_WEIRD_CHARS.length; ++i) {
-                String doc = "<root>"+INVALID_WEIRD_CHARS[i]+"</root>";
+        for (Base64Variant b64variant : sBase64Variants) {
+            for (String invalidWeirdChar : INVALID_WEIRD_CHARS) {
+                String doc = "<root>"+invalidWeirdChar+"</root>";
                 XMLStreamReader2 sr = getElemReader(doc);
                 try {
                     /*int count = */ sr.readElementAsBinary(resultBuffer, 0, resultBuffer.length, b64variant);
@@ -462,8 +454,7 @@ public abstract class ReaderBinaryTestBase
         // plus also skip non-padded variants, for now
 
         // So first we'll encode 1 to 6 bytes as base64
-        for (int bv = 0; bv < sPaddingVariants.length; ++bv) {
-            Base64Variant b64variant = sPaddingVariants[bv];
+        for (Base64Variant b64variant : sPaddingVariants) {
             for (int i = 1; i <= data.length; ++i) {
                 AsciiValueEncoder enc = new ValueEncoderFactory().getEncoder(b64variant, data, 0, i);
                 char[] cbuf = new char[20];
@@ -472,7 +463,7 @@ public abstract class ReaderBinaryTestBase
                 // and use all byte last 1, 2 or 3 chars
                 for (int j = 1; j <= 3; ++j) {
                     int testLen = clen-j;
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     sb.append("<root>");
                     sb.append(cbuf, 0, testLen);
                     sb.append("</root>");
@@ -504,10 +495,8 @@ public abstract class ReaderBinaryTestBase
     {
         final int REPS = 3;
         for (int j = 0; j < REPS; ++j) {
-            for (int bv = 0; bv < sBase64Variants.length; ++bv) {
-                Base64Variant b64variant = sBase64Variants[bv];
-                for (int i = 0; i < LEN_ATTR.length; ++i) {
-                    int size = LEN_ATTR[i];
+            for (Base64Variant b64variant : sBase64Variants) {
+                for (int size : LEN_ATTR) {
                     byte[] data = generateData(new Random(size), size);
                     char[] buffer = new char[4 + (data.length * 3 / 2)];
                     AsciiValueEncoder enc = new ValueEncoderFactory().getEncoder(b64variant, data, 0, data.length);
@@ -546,11 +535,9 @@ public abstract class ReaderBinaryTestBase
         throws XMLStreamException
     {
         // Hmmh. Here we need to skip testing of non-padded variants...
-        for (int bv = 0; bv < sPaddingVariants.length; ++bv) {
-            Base64Variant b64variant = sPaddingVariants[bv];
-            
-            for (int i = 0; i < INVALID_PADDING.length; ++i) {
-                String doc = "<root attr='"+INVALID_PADDING[i]+"' />";
+        for (Base64Variant b64variant : sPaddingVariants) {
+            for (String invalidPadding : INVALID_PADDING) {
+                String doc = "<root attr='"+invalidPadding+"' />";
                 XMLStreamReader2 sr = getElemReader(doc);
                 try {
                     /*byte[] data = */ sr.getAttributeAsBinary(0, b64variant);
@@ -566,10 +553,9 @@ public abstract class ReaderBinaryTestBase
     public void testInvalidAttrWhitespace()
         throws XMLStreamException
     {
-        for (int bv = 0; bv < sBase64Variants.length; ++bv) {
-            Base64Variant b64variant = sBase64Variants[bv];
-            for (int i = 0; i < INVALID_WS.length; ++i) {
-                String doc = "<root x='"+INVALID_WS[i]+"' />";
+        for (Base64Variant b64variant : sBase64Variants) {
+            for (String invalidWhiteSpace : INVALID_WS) {
+                String doc = "<root x='"+invalidWhiteSpace+"' />";
                 XMLStreamReader2 sr = getElemReader(doc);
                 try {
                     /*byte[] data = */ sr.getAttributeAsBinary(0, b64variant);
@@ -585,10 +571,9 @@ public abstract class ReaderBinaryTestBase
     public void testInvalidAttrWeirdChars()
         throws XMLStreamException
     {
-        for (int bv = 0; bv < sBase64Variants.length; ++bv) {
-            Base64Variant b64variant = sBase64Variants[bv];
-            for (int i = 0; i < INVALID_WEIRD_CHARS.length; ++i) {
-                String doc = "<root abc='"+INVALID_WEIRD_CHARS[i]+"'/>";
+        for (Base64Variant b64variant : sBase64Variants) {
+            for (String invalidWeirdChar : INVALID_WEIRD_CHARS) {
+                String doc = "<root abc='"+invalidWeirdChar+"'/>";
                 XMLStreamReader2 sr = getElemReader(doc);
                 try {
                     /*byte[] data = */ sr.getAttributeAsBinary(0, b64variant);
@@ -608,8 +593,7 @@ public abstract class ReaderBinaryTestBase
         final byte[] data = new byte[6];
         // plus also skip non-padded variants, for now
 
-        for (int bv = 0; bv < sPaddingVariants.length; ++bv) {
-            Base64Variant b64variant = sPaddingVariants[bv];
+        for (Base64Variant b64variant : sPaddingVariants) {
 
             // So first we'll encode 1 to 6 bytes as base64
             for (int i = 1; i <= data.length; ++i) {
@@ -620,7 +604,7 @@ public abstract class ReaderBinaryTestBase
                 // and use all byte last 1, 2 or 3 chars
                 for (int j = 1; j <= 3; ++j) {
                     int testLen = clen-j;
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     sb.append("<root attr='").append(cbuf, 0, testLen).append("'/>");
                     XMLStreamReader2 sr = getElemReader(sb.toString());
                     try {
@@ -662,7 +646,7 @@ public abstract class ReaderBinaryTestBase
         // Let's use base64 codec from RI here:
         AsciiValueEncoder enc = new ValueEncoderFactory().getEncoder(b64variant, data, 0, data.length);
 
-        StringBuffer sb = new StringBuffer(data.length * 2);
+        StringBuilder sb = new StringBuilder(data.length * 2);
         sb.append("<root>");
 
         // Without noise it's quite easy, just need enough space:
@@ -723,10 +707,9 @@ public abstract class ReaderBinaryTestBase
 
     private String buildMultiElemDoc(Base64Variant b64variant, byte[][] dataTable)
     {
-        StringBuffer sb = new StringBuffer(16 + dataTable.length * dataTable[0].length);
+        StringBuilder sb = new StringBuilder(16 + dataTable.length * dataTable[0].length);
         sb.append("<root>");
-        for (int i = 0; i < dataTable.length; ++i) {
-            byte[] data = dataTable[i];
+        for (byte[] data : dataTable) {
             char[] buffer = new char[4 + (data.length * 3 / 2)];
             AsciiValueEncoder enc = new ValueEncoderFactory().getEncoder(b64variant, data, 0, data.length);
             int len = enc.encodeMore(buffer, 0, buffer.length);

--- a/src/test/java/stax2/typed/WriterTestBase.java
+++ b/src/test/java/stax2/typed/WriterTestBase.java
@@ -105,8 +105,7 @@ public abstract class WriterTestBase
             0, 3, -9, 999, -77, 1000000000, -1000000000,
             Integer.MIN_VALUE, Integer.MAX_VALUE
         };
-        for (int i = 0; i < values.length; ++i) {
-            int value = values[i];
+        for (int value : values) {
             assertXML("<root>"+value+"</root>", writeIntElemDoc("root", value));
         }
     }
@@ -118,8 +117,7 @@ public abstract class WriterTestBase
             0, 3, -7, 123, -102, 1000000, -999999,
             Integer.MIN_VALUE, Integer.MAX_VALUE
         };
-        for (int i = 0; i < values.length; ++i) {
-            int value = values[i];
+        for (int value : values) {
             assertXML("<a attr='"+value+"'></a>", writeIntAttrDoc("a", "attr", value));
         }
     }
@@ -165,8 +163,7 @@ public abstract class WriterTestBase
             -987654321098765423L,
             Long.MIN_VALUE, Long.MAX_VALUE
         };
-        for (int i = 0; i < values.length; ++i) {
-            long value = values[i];
+        for (long value : values) {
             assertXML("<root>"+value+"</root>", writeLongElemDoc("root", value));
         }
     }
@@ -180,8 +177,7 @@ public abstract class WriterTestBase
             -987654321098765423L,
             Long.MIN_VALUE, Long.MAX_VALUE
         };
-        for (int i = 0; i < values.length; ++i) {
-            long value = values[i];
+        for (long value : values) {
             assertXML("<a attr='"+value+"'></a>", writeLongAttrDoc("a", "attr", value));
         }
     }
@@ -226,8 +222,7 @@ public abstract class WriterTestBase
             Float.MIN_VALUE, Float.MAX_VALUE,
             Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY
         };
-        for (int i = 0; i < values.length; ++i) {
-            float value = values[i];
+        for (float value : values) {
             assertXML("<root>"+value+"</root>", writeFloatElemDoc("root", value));
         }
     }
@@ -240,8 +235,7 @@ public abstract class WriterTestBase
             Float.MIN_VALUE, Float.MAX_VALUE,
             Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY
         };
-        for (int i = 0; i < values.length; ++i) {
-            float value = values[i];
+        for (float value : values) {
             assertXML("<a attr='"+value+"'></a>", writeFloatAttrDoc("a", "attr", value));
         }
     }
@@ -254,8 +248,7 @@ public abstract class WriterTestBase
             Double.MIN_VALUE, Double.MAX_VALUE,
             Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY
         };
-        for (int i = 0; i < values.length; ++i) {
-            double value = values[i];
+        for (double value : values) {
             assertXML("<root>"+value+"</root>", writeDoubleElemDoc("root", value));
         }
     }
@@ -268,8 +261,7 @@ public abstract class WriterTestBase
             Double.MIN_VALUE, Double.MAX_VALUE,
             Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY
         };
-        for (int i = 0; i < values.length; ++i) {
-            double value = values[i];
+        for (double value : values) {
             assertXML("<a attr='"+value+"'></a>", writeDoubleAttrDoc("a", "attr", value));
         }
     }

--- a/src/test/java/stax2/vstream/BaseStax2ValidationTest.java
+++ b/src/test/java/stax2/vstream/BaseStax2ValidationTest.java
@@ -73,7 +73,7 @@ public abstract class BaseStax2ValidationTest
         } catch (XMLValidationException vex) {
             String origMsg = vex.getMessage();
             String msg = (origMsg == null) ? "" : origMsg.toLowerCase();
-            if (msg.indexOf(failPhrase.toLowerCase()) < 0) {
+            if (!msg.contains(failPhrase.toLowerCase())) {
                 String actualMsg = "Expected validation exception for "
                     + failMsg + ", containing phrase '" + failPhrase
                     + "': got '" + origMsg + "'";

--- a/src/test/java/stax2/vwstream/BaseOutputTest.java
+++ b/src/test/java/stax2/vwstream/BaseOutputTest.java
@@ -16,8 +16,8 @@ abstract class BaseOutputTest
         throws XMLStreamException
     {
         XMLOutputFactory2 outf = getOutputFactory();
-        outf.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, Boolean.valueOf(nsAware));
-        outf.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.valueOf(repairing));
+        outf.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, nsAware);
+        outf.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, repairing);
 
         XMLStreamWriter2 strw = (XMLStreamWriter2)outf.createXMLStreamWriter(w);
         XMLValidationSchema schema = parseDTDSchema(dtdSrc);
@@ -33,7 +33,7 @@ abstract class BaseOutputTest
     {
         XMLOutputFactory2 outf = getOutputFactory();
         outf.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, true);
-        outf.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, Boolean.valueOf(repairing));
+        outf.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, repairing);
 
         XMLStreamWriter2 strw = (XMLStreamWriter2)outf.createXMLStreamWriter(w);
         XMLValidationSchema schema = parseW3CSchema(schemaSrc);

--- a/src/test/java/stax2/wstream/BaseWriterTest.java
+++ b/src/test/java/stax2/wstream/BaseWriterTest.java
@@ -19,9 +19,8 @@ public abstract class BaseWriterTest
         throws XMLStreamException
     {
         XMLOutputFactory2 f = getOutputFactory();
-        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, Boolean.TRUE);
-        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
-                      Boolean.TRUE);
+        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, true);
+        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, true);
         return (XMLStreamWriter2) f.createXMLStreamWriter(w);
     }
 
@@ -29,9 +28,8 @@ public abstract class BaseWriterTest
         throws XMLStreamException
     {
         XMLOutputFactory2 f = getOutputFactory();
-        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, Boolean.TRUE);
-        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
-                      Boolean.TRUE);
+        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, true);
+        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, true);
         return f.createXMLStreamWriter(w, enc);
     }
 
@@ -39,10 +37,8 @@ public abstract class BaseWriterTest
         throws XMLStreamException
     {
         XMLOutputFactory2 f = getOutputFactory();
-        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
-                      Boolean.FALSE);
-        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE,
-                      Boolean.valueOf(nsAware));
+        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, false);
+        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, nsAware);
         return (XMLStreamWriter2) f.createXMLStreamWriter(w);
     }
 
@@ -50,10 +46,8 @@ public abstract class BaseWriterTest
         throws XMLStreamException
     {
         XMLOutputFactory2 f = getOutputFactory();
-        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
-                      Boolean.FALSE);
-        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE,
-                      Boolean.valueOf(nsAware));
+        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, false);
+        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, nsAware);
         return f.createXMLStreamWriter(w, enc);
     }
 
@@ -61,10 +55,8 @@ public abstract class BaseWriterTest
         throws XMLStreamException
     {
         XMLOutputFactory2 f = getOutputFactory();
-        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
-                      Boolean.FALSE);
-        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE,
-                      Boolean.valueOf(nsAware));
+        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, false);
+        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, nsAware);
         return (XMLStreamWriter2) f.createXMLStreamWriter(os, enc);
     }
 }

--- a/src/test/java/stax2/wstream/TestClosing.java
+++ b/src/test/java/stax2/wstream/TestClosing.java
@@ -154,7 +154,7 @@ public class TestClosing
     XMLOutputFactory2 getFactory(boolean autoClose)
     {
         XMLOutputFactory2 f = getOutputFactory();
-        f.setProperty(XMLOutputFactory2.P_AUTO_CLOSE_OUTPUT, Boolean.valueOf(autoClose));
+        f.setProperty(XMLOutputFactory2.P_AUTO_CLOSE_OUTPUT, autoClose);
         return f;
     }
 

--- a/src/test/java/stax2/wstream/TestStreamWriter.java
+++ b/src/test/java/stax2/wstream/TestStreamWriter.java
@@ -78,8 +78,7 @@ public class TestStreamWriter
         XMLOutputFactory2 outf = getFactory(true, false);
         XMLInputFactory2 inf = getNewInputFactory();
 
-        for (int i = 0; i < encs.length; ++i) {
-            String enc = encs[i];
+        for (String enc : encs) {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             XMLStreamWriter sw = outf.createXMLStreamWriter(new OutputStreamWriter(os, enc));
             sw.writeStartDocument("1.0");
@@ -324,10 +323,8 @@ public class TestStreamWriter
         throws XMLStreamException
     {
         XMLOutputFactory2 f = getOutputFactory();
-        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE,
-                      Boolean.valueOf(nsAware));
-        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
-                      Boolean.valueOf(repairing));
+        f.setProperty(XMLStreamProperties.XSP_NAMESPACE_AWARE, nsAware);
+        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, repairing);
         return f;
     }
 

--- a/src/test/java/wstxtest/BaseWstxTest.java
+++ b/src/test/java/wstxtest/BaseWstxTest.java
@@ -22,19 +22,19 @@ public abstract class BaseWstxTest
     extends BaseStax2Test
     implements XMLStreamConstants
 {
-    final static HashMap<Integer,String> mTokenTypes = new HashMap<Integer,String>();
+    final static HashMap<Integer,String> mTokenTypes = new HashMap<>();
     static {
-        mTokenTypes.put(Integer.valueOf(START_ELEMENT), "START_ELEMENT");
-        mTokenTypes.put(Integer.valueOf(END_ELEMENT), "END_ELEMENT");
-        mTokenTypes.put(Integer.valueOf(START_DOCUMENT), "START_DOCUMENT");
-        mTokenTypes.put(Integer.valueOf(END_DOCUMENT), "END_DOCUMENT");
-        mTokenTypes.put(Integer.valueOf(CHARACTERS), "CHARACTERS");
-        mTokenTypes.put(Integer.valueOf(CDATA), "CDATA");
-        mTokenTypes.put(Integer.valueOf(COMMENT), "COMMENT");
-        mTokenTypes.put(Integer.valueOf(PROCESSING_INSTRUCTION), "PROCESSING_INSTRUCTION");
-        mTokenTypes.put(Integer.valueOf(DTD), "DTD");
-        mTokenTypes.put(Integer.valueOf(SPACE), "SPACE");
-        mTokenTypes.put(Integer.valueOf(ENTITY_REFERENCE), "ENTITY_REFERENCE");
+        mTokenTypes.put(START_ELEMENT, "START_ELEMENT");
+        mTokenTypes.put(END_ELEMENT, "END_ELEMENT");
+        mTokenTypes.put(START_DOCUMENT, "START_DOCUMENT");
+        mTokenTypes.put(END_DOCUMENT, "END_DOCUMENT");
+        mTokenTypes.put(CHARACTERS, "CHARACTERS");
+        mTokenTypes.put(CDATA, "CDATA");
+        mTokenTypes.put(COMMENT, "COMMENT");
+        mTokenTypes.put(PROCESSING_INSTRUCTION, "PROCESSING_INSTRUCTION");
+        mTokenTypes.put(DTD, "DTD");
+        mTokenTypes.put(SPACE, "SPACE");
+        mTokenTypes.put(ENTITY_REFERENCE, "ENTITY_REFERENCE");
     }
 
     /**
@@ -182,7 +182,7 @@ public abstract class BaseWstxTest
     protected static void setMinTextSegment(XMLInputFactory f, int len)
         throws XMLStreamException
     {
-        f.setProperty(WstxInputProperties.P_MIN_TEXT_SEGMENT, Integer.valueOf(len));
+        f.setProperty(WstxInputProperties.P_MIN_TEXT_SEGMENT, len);
     }
 
     /*
@@ -193,26 +193,22 @@ public abstract class BaseWstxTest
 
     protected static void setRepairing(XMLOutputFactory f, boolean state)
     {
-        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES,
-                      Boolean.valueOf(state));
+        f.setProperty(XMLOutputFactory.IS_REPAIRING_NAMESPACES, state);
     }
 
     protected static void setValidateStructure(XMLOutputFactory f, boolean state)
     {
-        f.setProperty(WstxOutputProperties.P_OUTPUT_VALIDATE_STRUCTURE,
-                      Boolean.valueOf(state));
+        f.setProperty(WstxOutputProperties.P_OUTPUT_VALIDATE_STRUCTURE, state);
     }
 
     protected static void setValidateContent(XMLOutputFactory f, boolean state)
     {
-        f.setProperty(WstxOutputProperties.P_OUTPUT_VALIDATE_CONTENT,
-                      Boolean.valueOf(state));
+        f.setProperty(WstxOutputProperties.P_OUTPUT_VALIDATE_CONTENT, state);
     }
 
     protected static void setValidateNames(XMLOutputFactory f, boolean state)
     {
-        f.setProperty(WstxOutputProperties.P_OUTPUT_VALIDATE_NAMES,
-                      Boolean.valueOf(state));
+        f.setProperty(WstxOutputProperties.P_OUTPUT_VALIDATE_NAMES, state);
     }
 
     protected static void setValidateAll(XMLOutputFactory f, boolean state)
@@ -224,8 +220,7 @@ public abstract class BaseWstxTest
 
     protected static void setFixContent(XMLOutputFactory f, boolean state)
     {
-        f.setProperty(WstxOutputProperties.P_OUTPUT_FIX_CONTENT,
-                      Boolean.valueOf(state));
+        f.setProperty(WstxOutputProperties.P_OUTPUT_FIX_CONTENT, state);
     }
 
     /*
@@ -300,7 +295,7 @@ public abstract class BaseWstxTest
 
     protected static String tokenTypeDesc(int tt)
     {
-        String desc = mTokenTypes.get(Integer.valueOf(tt));
+        String desc = mTokenTypes.get(tt);
         return (desc == null) ? ("["+tt+"]") : desc;
     }
 
@@ -553,7 +548,7 @@ public abstract class BaseWstxTest
             return "\\t";
         }
         if (ch > 127 || ch < 32) {
-            StringBuffer sb = new StringBuffer(6);
+            StringBuilder sb = new StringBuilder(6);
             sb.append("\\u");
             String hex = Integer.toHexString((int)ch);
             for (int i = 0, len = 4 - hex.length(); i < len; i++) {
@@ -572,7 +567,7 @@ public abstract class BaseWstxTest
         }
 
         int len = str.length();
-        StringBuffer sb = new StringBuffer(len + 64);
+        StringBuilder sb = new StringBuilder(len + 64);
         for (int i = 0; i < len; ++i) {
             char c = str.charAt(i);
             String res = printable(c);
@@ -592,7 +587,7 @@ public abstract class BaseWstxTest
         }
 
         int len = str.length();
-        StringBuffer sb = new StringBuffer(len + 64);
+        StringBuilder sb = new StringBuilder(len + 64);
         for (int i = 0; i < len; ++i) {
             char c = str.charAt(i);
             String res = printableWithSpaces(c);

--- a/src/test/java/wstxtest/cfg/InputConfigIterator.java
+++ b/src/test/java/wstxtest/cfg/InputConfigIterator.java
@@ -12,7 +12,7 @@ import javax.xml.stream.XMLInputFactory;
  */
 public class InputConfigIterator
 {
-    final ArrayList<InputTestConfig> mConfigs = new ArrayList<InputTestConfig>();
+    final ArrayList<InputTestConfig> mConfigs = new ArrayList<>();
 
     /*
     /////////////////////////////////////////////////
@@ -46,8 +46,8 @@ public class InputConfigIterator
 
         // First need to initialize the factory with first settings:
         final int len = mConfigs.size();
-        for (int i = 0; i < len; ++i) {
-            mConfigs.get(i).nextConfig(f);
+        for (InputTestConfig mConfig : mConfigs) {
+            mConfig.nextConfig(f);
         }
 
         // And then the main iteration
@@ -89,7 +89,7 @@ public class InputConfigIterator
     public String toString()
     {
         int len = mConfigs.size();
-        StringBuffer sb = new StringBuffer(16 + (len << 4));
+        StringBuilder sb = new StringBuilder(16 + (len << 4));
         sb.append('(');
         sb.append(len);
         sb.append(") ");

--- a/src/test/java/wstxtest/msv/TestW3CSchema.java
+++ b/src/test/java/wstxtest/msv/TestW3CSchema.java
@@ -347,12 +347,8 @@ public class TestW3CSchema
         // Then invalid?
         String XML = "<foobar />";
         XMLStreamReader2 sr = getReader(XML);
-        sr.setValidationProblemHandler(new ValidationProblemHandler() {
-            @Override
-            public void reportProblem(XMLValidationProblem problem)
-                    throws XMLValidationException {
-                throw new LocalValidationError(problem);
-            }
+        sr.setValidationProblemHandler(problem -> {
+            throw new LocalValidationError(problem);
         });
         sr.validateAgainst(schema);
         try {

--- a/src/test/java/wstxtest/msv/TestWsdlValidation.java
+++ b/src/test/java/wstxtest/msv/TestWsdlValidation.java
@@ -38,7 +38,7 @@ public class TestWsdlValidation extends BaseStax2Test
 
 	     @Override
 	     public void error(Locator[] locs, String errorMessage, Exception nestedException) {
-	         StringBuffer errors = new StringBuffer();
+	         StringBuilder errors = new StringBuilder();
 	         for (Locator loc : locs) {
 	             errors.append("in " + loc.getSystemId() + " " + loc.getLineNumber() + ":"
 	                     + loc.getColumnNumber());
@@ -48,7 +48,7 @@ public class TestWsdlValidation extends BaseStax2Test
 
 	     @Override
 	     public void warning(Locator[] locs, String errorMessage) {
-	         StringBuffer errors = new StringBuffer();
+	         StringBuilder errors = new StringBuilder();
 	         for (Locator loc : locs) {
 	             errors.append("in " + loc.getSystemId() + " " + loc.getLineNumber() + ":"
 	                     + loc.getColumnNumber());

--- a/src/test/java/wstxtest/osgi/TestBasic.java
+++ b/src/test/java/wstxtest/osgi/TestBasic.java
@@ -20,7 +20,7 @@ public class TestBasic
         BundleContext ctxt = (BundleContext) Proxy.newProxyInstance(BundleContext.class.getClassLoader(), new Class[] { BundleContext.class }, h);
         WstxBundleActivator act = new WstxBundleActivator();
 
-        // won't prove much... but at least there's noo fundamental flaw:
+        // won't prove much... but at least there's no fundamental flaw:
         act.start(ctxt);
     }
 

--- a/src/test/java/wstxtest/stream/BaseStreamTest.java
+++ b/src/test/java/wstxtest/stream/BaseStreamTest.java
@@ -117,7 +117,7 @@ public abstract class BaseStreamTest
             type = sr.next();
         } while ((type == SPACE) || (type == DTD));
         
-        StringBuffer act = new StringBuffer(1000);
+        StringBuilder act = new StringBuilder(1000);
         int count = 0;
 
         do {

--- a/src/test/java/wstxtest/stream/TestAttributeLimits.java
+++ b/src/test/java/wstxtest/stream/TestAttributeLimits.java
@@ -16,7 +16,7 @@ public class TestAttributeLimits extends BaseStreamTest
     {
         final int max = 100;
         XMLInputFactory factory = getNewInputFactory();
-        factory.setProperty(WstxInputProperties.P_MAX_ATTRIBUTES_PER_ELEMENT, Integer.valueOf(50));
+        factory.setProperty(WstxInputProperties.P_MAX_ATTRIBUTES_PER_ELEMENT, 50);
         Reader reader = new Reader() {
             StringReader sreader = new StringReader("<ns:element xmlns:ns=\"http://foo.com\"");
             int count;
@@ -133,7 +133,7 @@ public class TestAttributeLimits extends BaseStreamTest
         };
         try {
             XMLInputFactory factory = getNewInputFactory();
-            factory.setProperty(WstxInputProperties.P_MAX_ATTRIBUTE_SIZE, Integer.valueOf(100));
+            factory.setProperty(WstxInputProperties.P_MAX_ATTRIBUTE_SIZE, 100);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.END_DOCUMENT) {
             }

--- a/src/test/java/wstxtest/stream/TestCharacterLimits.java
+++ b/src/test/java/wstxtest/stream/TestCharacterLimits.java
@@ -20,7 +20,7 @@ public class TestCharacterLimits
         try {
             Reader reader = createLongReader("", "", false);
             XMLInputFactory factory = getNewInputFactory();
-            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, Integer.valueOf(1000));
+            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, 1000);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.START_ELEMENT) {
             }
@@ -35,7 +35,7 @@ public class TestCharacterLimits
         try {
             Reader reader = createLongReader("", "", false);
             XMLInputFactory factory = getNewInputFactory();
-            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, Integer.valueOf(100000));
+            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, 100000);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.START_ELEMENT) {
             }
@@ -51,7 +51,7 @@ public class TestCharacterLimits
         try {
             Reader reader = createLongReader("", "", true);
             XMLInputFactory factory = getNewInputFactory();
-            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, Integer.valueOf(1000));
+            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, 1000);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.START_ELEMENT) {
             }
@@ -66,7 +66,7 @@ public class TestCharacterLimits
         try {
             Reader reader = createLongReader("", "", true);
             XMLInputFactory factory = getNewInputFactory();
-            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, Integer.valueOf(50000));
+            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, 50000);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.START_ELEMENT) {
             }
@@ -83,7 +83,7 @@ public class TestCharacterLimits
         try {
             Reader reader = createLongReader("<![CDATA[", "]]>", true);
             XMLInputFactory factory = getNewInputFactory();
-            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, Integer.valueOf(50000));
+            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, 50000);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.START_ELEMENT) {
             }
@@ -99,7 +99,7 @@ public class TestCharacterLimits
     public void testLongCDATANextTag() throws Exception {
         Reader reader = createLongReader("<![CDATA[", "]]>", true);
         XMLInputFactory factory = getNewInputFactory();
-        factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, Integer.valueOf(1000));
+        factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, 1000);
         XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
         try {
             int tokens = 0;
@@ -117,7 +117,7 @@ public class TestCharacterLimits
         try {
             Reader reader = createLongReader("<!--", "-->", true);
             XMLInputFactory factory = getNewInputFactory();
-            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, Integer.valueOf(1000));
+            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, 1000);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.COMMENT) {
             }
@@ -133,7 +133,7 @@ public class TestCharacterLimits
         try {
             Reader reader = createLongReader("<!--", "-->", true);
             XMLInputFactory factory = getNewInputFactory();
-            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, Integer.valueOf(1000));
+            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, 1000);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.COMMENT) {
             }
@@ -149,7 +149,7 @@ public class TestCharacterLimits
             Reader reader = createLongReader("<!--", "-->", true);
             XMLInputFactory factory = getNewInputFactory();
             factory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
-            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, Integer.valueOf(1000));
+            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, 1000);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.START_ELEMENT) {
             }
@@ -165,7 +165,7 @@ public class TestCharacterLimits
             Reader reader = createLongReader("", "", true);
             XMLInputFactory factory = getNewInputFactory();
             factory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.TRUE);
-            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, Integer.valueOf(1000));
+            factory.setProperty(WstxInputProperties.P_MAX_TEXT_LENGTH, 1000);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.START_ELEMENT) {
             }

--- a/src/test/java/wstxtest/stream/TestElementLimits.java
+++ b/src/test/java/wstxtest/stream/TestElementLimits.java
@@ -45,7 +45,7 @@ public class TestElementLimits extends BaseStreamTest
             }
         };
         XMLInputFactory factory = getNewInputFactory();
-        factory.setProperty(WstxInputProperties.P_MAX_ELEMENT_DEPTH, Integer.valueOf(25));
+        factory.setProperty(WstxInputProperties.P_MAX_ELEMENT_DEPTH, 25);
         XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
         try {
             while (xmlreader.next() != XMLStreamReader.END_ELEMENT) {
@@ -83,7 +83,7 @@ public class TestElementLimits extends BaseStreamTest
             }
         };
         XMLInputFactory factory = getNewInputFactory();
-        factory.setProperty(WstxInputProperties.P_MAX_CHILDREN_PER_ELEMENT, Integer.valueOf(100));
+        factory.setProperty(WstxInputProperties.P_MAX_CHILDREN_PER_ELEMENT, 100);
         try {
             XMLStreamReader xmlreader = factory.createXMLStreamReader(reader);
             while (xmlreader.next() != XMLStreamReader.END_DOCUMENT) {
@@ -99,7 +99,7 @@ public class TestElementLimits extends BaseStreamTest
         
         try {
             XMLInputFactory factory = getNewInputFactory();
-            factory.setProperty(WstxInputProperties.P_MAX_ELEMENT_COUNT, Integer.valueOf(100));
+            factory.setProperty(WstxInputProperties.P_MAX_ELEMENT_COUNT, 100);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(createManyElementReader());
             while (xmlreader.next() != XMLStreamReader.END_DOCUMENT) {
             }
@@ -110,8 +110,7 @@ public class TestElementLimits extends BaseStreamTest
         XMLInputFactory factory = getNewInputFactory();
         XMLStreamReader xmlreader = factory.createXMLStreamReader(createManyElementReader());
         try {
-            ((BasicStreamReader)xmlreader).setProperty(WstxInputProperties.P_MAX_ELEMENT_COUNT,
-                    Integer.valueOf(100));
+            ((BasicStreamReader)xmlreader).setProperty(WstxInputProperties.P_MAX_ELEMENT_COUNT, 100);
             while (xmlreader.next() != XMLStreamReader.END_DOCUMENT) {
             }
             fail("Should have failed");
@@ -123,7 +122,7 @@ public class TestElementLimits extends BaseStreamTest
     public void testCharacterLimit() throws Exception {
         try {
             XMLInputFactory factory = getNewInputFactory();
-            factory.setProperty(WstxInputProperties.P_MAX_CHARACTERS, Integer.valueOf(100));
+            factory.setProperty(WstxInputProperties.P_MAX_CHARACTERS, 100);
             XMLStreamReader xmlreader = factory.createXMLStreamReader(createManyElementReader());
             while (xmlreader.next() != XMLStreamReader.END_DOCUMENT) {
             }

--- a/src/test/java/wstxtest/stream/TestEncodingDetection.java
+++ b/src/test/java/wstxtest/stream/TestEncodingDetection.java
@@ -58,7 +58,7 @@ public class TestEncodingDetection
         /* Let's first check a somewhat common case; figuring out UTF-16
          * encoded doc (which has to have BOM, thus); first, big-endian
          */
-        StringBuffer sb = new StringBuffer(XML);
+        StringBuilder sb = new StringBuilder(XML);
         sb.setCharAt(0, (char) 0xFEFF);
 
         byte[] b = getUtf16Bytes(sb.toString(), true);
@@ -94,9 +94,9 @@ public class TestEncodingDetection
             "037", "277", "278", "280", "284", "285", "297",
             "420", "424", "500", "870", "871", "918",
         };
- 
-        for (int i = 0; i < subtypes.length; ++i) {
-            String actEnc = ENC_EBCDIC_IN_PREFIX + subtypes[i];
+
+        for (String subtype : subtypes) {
+            String actEnc = ENC_EBCDIC_IN_PREFIX + subtype;
             String xml = "<?xml version='1.0' encoding='"+actEnc+"' ?>"
                 +"<root attr='123'>rock &amp; roll!<!-- comment --></root>";
             byte[] bytes = xml.getBytes(actEnc);
@@ -108,7 +108,7 @@ public class TestEncodingDetection
             assertEquals(actEnc, sr.getCharacterEncodingScheme());
             
             // Found encoding, though, can be changed
-            String expEnc = ENC_EBCDIC_OUT_PREFIX + subtypes[i];
+            String expEnc = ENC_EBCDIC_OUT_PREFIX + subtype;
             assertEquals(expEnc, sr.getEncoding());
             
             assertTokenType(START_ELEMENT, sr.next());

--- a/src/test/java/wstxtest/stream/TestEntityLimits.java
+++ b/src/test/java/wstxtest/stream/TestEntityLimits.java
@@ -35,7 +35,7 @@ public class TestEntityLimits
         sr.close();
 
         // and with max depth of 3 as well
-        f.setProperty(WstxInputProperties.P_MAX_ENTITY_DEPTH, Integer.valueOf(3));
+        f.setProperty(WstxInputProperties.P_MAX_ENTITY_DEPTH, 3);
         sr = f.createXMLStreamReader(new StringReader(XML));
         assertTokenType(DTD, sr.next());
         assertTokenType(START_ELEMENT, sr.next());
@@ -44,7 +44,7 @@ public class TestEntityLimits
         sr.close();
 
         // but not with 2
-        f.setProperty(WstxInputProperties.P_MAX_ENTITY_DEPTH, Integer.valueOf(2));
+        f.setProperty(WstxInputProperties.P_MAX_ENTITY_DEPTH, 2);
         sr = f.createXMLStreamReader(new StringReader(XML));
         assertTokenType(DTD, sr.next());
         assertTokenType(START_ELEMENT, sr.next());
@@ -79,7 +79,7 @@ public class TestEntityLimits
         sr.close();
 
         // and with max set to 21 expansions
-        f.setProperty(WstxInputProperties.P_MAX_ENTITY_COUNT, Integer.valueOf(21));
+        f.setProperty(WstxInputProperties.P_MAX_ENTITY_COUNT, 21);
         sr = f.createXMLStreamReader(new StringReader(XML));
         assertTokenType(DTD, sr.next());
         assertTokenType(START_ELEMENT, sr.next());
@@ -89,7 +89,7 @@ public class TestEntityLimits
         sr.close();
 
         // but not with one less
-        f.setProperty(WstxInputProperties.P_MAX_ENTITY_COUNT, Integer.valueOf(20));
+        f.setProperty(WstxInputProperties.P_MAX_ENTITY_COUNT, 20);
         sr = f.createXMLStreamReader(new StringReader(XML));
         assertTokenType(DTD, sr.next());
         assertTokenType(START_ELEMENT, sr.next());

--- a/src/test/java/wstxtest/stream/TestEntityRead.java
+++ b/src/test/java/wstxtest/stream/TestEntityRead.java
@@ -127,7 +127,7 @@ public class TestEntityRead
         String XML = "<root>ok: &myent;&myent2;</root>";
         String EXP_TEXT = "ok: (simple)expand to ([text])";
         XMLInputFactory fact = getConfiguredFactory(true, true);
-        Map<String,String> m = new HashMap<String,String>();
+        Map<String,String> m = new HashMap<>();
         m.put("myent", "(simple)");
         m.put("myent3", "[text]");
         m.put("myent2", "expand to (&myent3;)");

--- a/src/test/java/wstxtest/stream/TestLocation.java
+++ b/src/test/java/wstxtest/stream/TestLocation.java
@@ -57,7 +57,7 @@ public class TestLocation
         final int ROWS = 1000;
 
         // First, let's create xml doc:
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("<a>");
         Random r = new Random(SEED);
         for (int i = 0; i < ROWS; ++i) {
@@ -107,7 +107,7 @@ public class TestLocation
             assertEquals(col, loc.getColumnNumber());
             assertEquals(chars, loc.getCharacterOffset());
 
-            sb = new StringBuffer();
+            sb = new StringBuilder();
             boolean offByOne = false;
             switch (r.nextInt() % 3) {
             case 1:
@@ -275,7 +275,7 @@ public class TestLocation
     public List<String> doTestCommentLocation(String input, boolean supportDtd)
             throws XMLStreamException
     {
-    	List<String> lstLineData = new ArrayList<String>();
+    	List<String> lstLineData = new ArrayList<>();
     	Reader reader = new StringReader(input);
 
         // Force woodstox factory instance

--- a/src/test/java/wstxtest/util/TestArgUtil.java
+++ b/src/test/java/wstxtest/util/TestArgUtil.java
@@ -24,7 +24,7 @@ public class TestArgUtil
 
         // and then errors:
         try {
-            /*boolean b =*/ ArgUtil.convertToBoolean("test", Integer.valueOf(0));
+            /*boolean b =*/ ArgUtil.convertToBoolean("test", 0);
             fail("Expected an IllegalArgumentException");
         } catch (IllegalArgumentException iae) { }
 
@@ -37,14 +37,14 @@ public class TestArgUtil
     public void testInt()
     {
         assertEquals(14, ArgUtil.convertToInt("test", "14", 0));
-        assertEquals(14, ArgUtil.convertToInt("test", Integer.valueOf(14), 0));
-        assertEquals(14, ArgUtil.convertToInt("test", Long.valueOf(14L), 0));
-        assertEquals(14, ArgUtil.convertToInt("test", Short.valueOf((short) 14), 0));
-        assertEquals(14, ArgUtil.convertToInt("test", Byte.valueOf((byte) 14), 0));
+        assertEquals(14, ArgUtil.convertToInt("test", 14, 0));
+        assertEquals(14, ArgUtil.convertToInt("test", 14L, 0));
+        assertEquals(14, ArgUtil.convertToInt("test", (short) 14, 0));
+        assertEquals(14, ArgUtil.convertToInt("test", (byte) 14, 0));
 
         // and then errors:
         try {
-            /*int x =*/ ArgUtil.convertToInt("test", new HashMap<Object,Object>(), 0);
+            /*int x =*/ ArgUtil.convertToInt("test", new HashMap<>(), 0);
             fail("Expected an IllegalArgumentException");
         } catch (IllegalArgumentException iae) { }
 

--- a/src/test/java/wstxtest/util/TestBijectiveNsMap.java
+++ b/src/test/java/wstxtest/util/TestBijectiveNsMap.java
@@ -37,7 +37,7 @@ public class TestBijectiveNsMap
         // and then let's mask it
         nsMap = nsMap.createChild();
         nsMap.addMapping("ns", "xyz");
-        assertEquals(0, nsMap.getPrefixesBoundToUri("abc", new ArrayList<String>()).size());
+        assertEquals(0, nsMap.getPrefixesBoundToUri("abc", new ArrayList<>()).size());
 
         // and finally, let's re-bind it
         nsMap = nsMap.createChild();

--- a/src/test/java/wstxtest/util/TestDataUtil.java
+++ b/src/test/java/wstxtest/util/TestDataUtil.java
@@ -22,17 +22,17 @@ public class TestDataUtil
     {
         // First, no match:
 
-        Collection<Object> c1 = new HashSet<Object>();
+        Collection<Object> c1 = new HashSet<>();
         c1.add("foo");
         c1.add(new String("bar"));
-        Collection<Object> c2 = new ArrayList<Object>();
+        Collection<Object> c2 = new ArrayList<>();
         c2.add("foobar");
-        c2.add(Integer.valueOf(3));
+        c2.add(3);
 
         assertFalse(DataUtil.anyValuesInCommon(c1, c2));
 
         // Then a match
-        c1.add(Integer.valueOf(3));
+        c1.add(3);
         assertTrue(DataUtil.anyValuesInCommon(c1, c2));
 
         // And another one:

--- a/src/test/java/wstxtest/util/TestStringUtil.java
+++ b/src/test/java/wstxtest/util/TestStringUtil.java
@@ -13,14 +13,14 @@ public class TestStringUtil
 {
     public void testConcatEntries()
     {
-        List<String> l = new ArrayList<String>();
+        List<String> l = new ArrayList<>();
         l.add("first");
         l.add("second");
         l.add("third");
         assertEquals("first, second and third",
                      StringUtil.concatEntries(l, ", ", " and "));
 
-        l = new ArrayList<String>();
+        l = new ArrayList<>();
         l.add("the only");
         assertEquals("the only",
                      StringUtil.concatEntries(l, ", ", " and "));

--- a/src/test/java/wstxtest/util/TestWordResolver.java
+++ b/src/test/java/wstxtest/util/TestWordResolver.java
@@ -59,21 +59,17 @@ public class TestWordResolver
 
     private void checkResolver(String[] words, String[] missingWords)
     {
-        TreeSet<String> set = new TreeSet<String>();
-        for (int i = 0, len = words.length; i < len; ++i) {
-            set.add(words[i]);
+        TreeSet<String> set = new TreeSet<>();
+        for (String word : words) {
+            set.add(word);
         }
 
         WordResolver wr = WordResolver.constructInstance(set);
 
         assertEquals(wr.size(), set.size());
 
-        Iterator<String> it = set.iterator();
-
         // Let's first check if words that should be there, are:
-        while (it.hasNext()) {
-            String str = it.next();
-
+        for (String str : set) {
             assertEquals(str, wr.find(str));
             // And then, let's make sure intern()ing isn't needed:
             assertEquals(str, wr.find(""+str));
@@ -86,8 +82,8 @@ public class TestWordResolver
         }
 
         // And then that ones shouldn't be there aren't:
-        for (int i = 0, len = missingWords.length; i < len; ++i) {
-            checkNotFind(wr, missingWords[i]);
+        for (String missingWord : missingWords) {
+            checkNotFind(wr, missingWord);
         }
     }
 

--- a/src/test/java/wstxtest/util/TestWordSet.java
+++ b/src/test/java/wstxtest/util/TestWordSet.java
@@ -18,7 +18,7 @@ public class TestWordSet
 
     public void testNormal()
     {
-        TreeSet<String> set = new TreeSet<String>();
+        TreeSet<String> set = new TreeSet<>();
 
         set.add("word");
         set.add("123");

--- a/src/test/java/wstxtest/vstream/BaseValidationTest.java
+++ b/src/test/java/wstxtest/vstream/BaseValidationTest.java
@@ -87,7 +87,7 @@ public abstract class BaseValidationTest
         } catch (XMLValidationException vex) {
             String origMsg = vex.getMessage();
             String msg = (origMsg == null) ? "" : origMsg.toLowerCase();
-            if (msg.indexOf(failPhrase.toLowerCase()) < 0) {
+            if (!msg.contains(failPhrase.toLowerCase())) {
                 String actualMsg = "Expected validation exception for "
                     + failMsg + ", containing phrase '" + failPhrase
                     + "': got '" + origMsg + "'";

--- a/src/test/java/wstxtest/vstream/TestDTDErrorCollection104Test.java
+++ b/src/test/java/wstxtest/vstream/TestDTDErrorCollection104Test.java
@@ -42,7 +42,7 @@ public class TestDTDErrorCollection104Test
 +"<!ELEMENT notval EMPTY>\n"
 ;
 
-        final List<XMLValidationProblem> probs = new ArrayList<XMLValidationProblem>();
+        final List<XMLValidationProblem> probs = new ArrayList<>();
         
         XMLInputFactory f = getInputFactory();
         setCoalescing(f, true);
@@ -55,13 +55,7 @@ public class TestDTDErrorCollection104Test
                     new StringReader(DOC));
             
             sr.validateAgainst(schema);
-            sr.setValidationProblemHandler(new ValidationProblemHandler() {
-                @Override
-                public void reportProblem(XMLValidationProblem problem)
-                        throws XMLValidationException {
-                    probs.add(problem);
-                }
-            });
+            sr.setValidationProblemHandler(probs::add);
 
             assertTokenType(START_ELEMENT, sr.next());
             assertEquals("map", sr.getLocalName());

--- a/src/test/java/wstxtest/vstream/TestInvalidAttributeValue.java
+++ b/src/test/java/wstxtest/vstream/TestInvalidAttributeValue.java
@@ -39,16 +39,10 @@ public class TestInvalidAttributeValue
         XMLStreamReader2 sr = (XMLStreamReader2)f.createXMLStreamReader(
                 new StringReader(DOC));
 
-        final List<XMLValidationProblem> probs = new ArrayList<XMLValidationProblem>();
+        final List<XMLValidationProblem> probs = new ArrayList<>();
         
         sr.validateAgainst(schema);
-        sr.setValidationProblemHandler(new ValidationProblemHandler() {
-            @Override
-            public void reportProblem(XMLValidationProblem problem)
-                    throws XMLValidationException {
-                probs.add(problem);
-            }
-        });
+        sr.setValidationProblemHandler(probs::add);
 
         assertTokenType(START_ELEMENT, sr.next());
         assertEquals("root", sr.getLocalName());

--- a/src/test/java/wstxtest/vstream/TestXMLReporter.java
+++ b/src/test/java/wstxtest/vstream/TestXMLReporter.java
@@ -189,7 +189,7 @@ public class TestXMLReporter
             if (actMsg == null) {
                 actMsg = "";
             }
-            if (actMsg.indexOf(expMsg) < 0) {
+            if (!actMsg.contains(expMsg)) {
                 fail("Expected failure to contain phrase '"+expMsg+"', did not, was: '"+actMsg+"'");
             }
         }

--- a/src/test/java/wstxtest/wstream/TestContentValidation.java
+++ b/src/test/java/wstxtest/wstream/TestContentValidation.java
@@ -102,7 +102,7 @@ public class TestContentValidation
                 XMLStreamReader sr = getReader(output);
                 assertTokenType(START_ELEMENT, sr.next());
                 assertTokenType(COMMENT, sr.next());
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 sb.append(getAndVerifyText(sr));
                 
                 // May get another one too...?
@@ -222,7 +222,7 @@ public class TestContentValidation
                     int type = sr.next();
                     
                     assertTokenType(CDATA, type);
-                    StringBuffer sb = new StringBuffer();
+                    StringBuilder sb = new StringBuilder();
                     sb.append(getAndVerifyText(sr));
                     
                     // Should be getting one or more segments...

--- a/src/test/java/wstxtest/wstream/TestEmptyElementWriter.java
+++ b/src/test/java/wstxtest/wstream/TestEmptyElementWriter.java
@@ -39,7 +39,7 @@ public class TestEmptyElementWriter
     {
         XMLOutputFactory f = getOutputFactory();
         // test with simple handler that lists explicitly all tags to close
-        Set<String> tags = new HashSet<String> ();
+        Set<String> tags = new HashSet<>();
         tags.add("a");
         f.setProperty(WstxOutputProperties.P_OUTPUT_EMPTY_ELEMENT_HANDLER,
                 new EmptyElementHandler.SetEmptyElementHandler(tags));

--- a/src/test/java/wstxtest/wstream/TestEscaping.java
+++ b/src/test/java/wstxtest/wstream/TestEscaping.java
@@ -42,10 +42,9 @@ public class TestEscaping
     {
         // Let's try out 2 main encoding types:
         String[] ENC = new String[] { "UTF-8", "ISO-8859-1", "US-ASCII" };
-        for (int encIx = 0; encIx < ENC.length; ++encIx) {
+        for (String enc : ENC) {
             // And 3 writer types:
             for (int type = 0; type < 3; ++type) {
-                String enc = ENC[encIx];
                 XMLOutputFactory2 f = getFactory(type, escaping);
                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                 XMLStreamWriter sw = f.createXMLStreamWriter(out, enc);

--- a/src/test/java/wstxtest/wstream/TestInvalidChars.java
+++ b/src/test/java/wstxtest/wstream/TestInvalidChars.java
@@ -20,7 +20,7 @@ public class TestInvalidChars
 {
     final static String INVALID_TEXT = "\u0003";
 
-    final static Character REPL_CHAR = Character.valueOf('*');
+    final static Character REPL_CHAR = '*';
 
     // // First let's verify that we do catch problematic chars
 
@@ -153,7 +153,7 @@ public class TestInvalidChars
     }
 
     private void verifyValidReplacement(int evtType, XMLStreamWriter sw, String doc, boolean strict) {
-        if (doc.indexOf(REPL_CHAR.charValue()) < 0) { // no replacement...
+        if (doc.indexOf(REPL_CHAR) < 0) { // no replacement...
             handleFailure(sw,
                     "Failed to replace invalid char, event " + tokenTypeDesc(evtType) + ", xml = '" + doc + "'",
                     strict);
@@ -206,7 +206,7 @@ public class TestInvalidChars
         setRepairing(f, false);
         setValidateContent(f, true);
         f.setProperty(WstxOutputProperties.P_OUTPUT_INVALID_CHAR_HANDLER,
-                (replChar == null) ? null : new InvalidCharHandler.ReplacingHandler(replChar.charValue()));
+                (replChar == null) ? null : new InvalidCharHandler.ReplacingHandler(replChar));
         return f;
     }
 }

--- a/src/test/java/wstxtest/wstream/TestNameValidation.java
+++ b/src/test/java/wstxtest/wstream/TestNameValidation.java
@@ -72,21 +72,18 @@ public class TestNameValidation
                 /* Note: when not repairing, need not worry about
                  * namespace binding... makes life easier here
                  */
-                for (int i = 0; i < VALID_NS_NAMES.length; ++i) {
-                    String name = VALID_NS_NAMES[i];
+                for (String name : VALID_NS_NAMES) {
                     sw.writeEmptyElement(name);
                     sw.writeStartElement(name);
                     sw.writeEndElement();
                 }
-                for (int i = 0; i < VALID_NS_PREFIXES.length; ++i) {
-                    String prefix = VALID_NS_PREFIXES[i];
+                for (String prefix : VALID_NS_PREFIXES) {
                     sw.writeEmptyElement(prefix, "elem", DUMMY_URL);
                     sw.writeStartElement(prefix, "elem", DUMMY_URL);
                     sw.writeEndElement();
                 }
             } else {
-                for (int i = 0; i < VALID_NON_NS_NAMES.length; ++i) {
-                    String name = VALID_NON_NS_NAMES[i];
+                for (String name : VALID_NON_NS_NAMES) {
                     sw.writeEmptyElement(name);
                     sw.writeStartElement(name);
                     sw.writeEndElement();
@@ -104,17 +101,14 @@ public class TestNameValidation
         for (int n = 0; n < 2; ++n) {
             boolean ns = (n == 1);
             if (ns) { // need to check both prefixes and names
-                for (int i = 0; i < INVALID_NS_NAMES.length; ++i) {
-                    String name = INVALID_NS_NAMES[i];
-                    for (int j = 0; j < INVALID_NS_PREFIXES.length; ++j) {
-                        String prefix = INVALID_NS_PREFIXES[j];
+                for (String name : INVALID_NS_NAMES) {
+                    for (String prefix : INVALID_NS_PREFIXES) {
                         doTestInvalidElemName(true, prefix, name);
                         doTestInvalidElemName(true, null, name);
                     }
                 }
             } else {
-                for (int i = 0; i < INVALID_NON_NS_NAMES.length; ++i) {
-                    String name = INVALID_NON_NS_NAMES[i];
+                for (String name : INVALID_NON_NS_NAMES) {
                     doTestInvalidElemName(false, null, name);
                 }
             }
@@ -236,17 +230,14 @@ public class TestNameValidation
             sw.writeStartElement("dummy");
 
             if (ns) {
-                for (int i = 0; i < VALID_NS_NAMES.length; ++i) {
-                    String name = VALID_NS_NAMES[i];
+                for (String name : VALID_NS_NAMES) {
                     sw.writeAttribute(name, ATTR_VALUE);
                 }
-                for (int i = 0; i < VALID_NS_PREFIXES.length; ++i) {
-                    String prefix = VALID_NS_PREFIXES[i];
+                for (String prefix : VALID_NS_PREFIXES) {
                     sw.writeAttribute(prefix, DUMMY_URL, "attr", ATTR_VALUE);
                 }
             } else {
-                for (int i = 0; i < VALID_NON_NS_NAMES.length; ++i) {
-                    String name = VALID_NON_NS_NAMES[i];
+                for (String name : VALID_NON_NS_NAMES) {
                     sw.writeAttribute(name, ATTR_VALUE);
                 }
             }
@@ -262,17 +253,14 @@ public class TestNameValidation
         for (int n = 0; n < 2; ++n) {
             boolean ns = (n == 1);
             if (ns) { // need to check both prefixes and names
-                for (int i = 0; i < INVALID_NS_NAMES.length; ++i) {
-                    String name = INVALID_NS_NAMES[i];
-                    for (int j = 0; j < INVALID_NS_PREFIXES.length; ++j) {
-                        String prefix = INVALID_NS_PREFIXES[j];
+                for (String name : INVALID_NS_NAMES) {
+                    for (String prefix : INVALID_NS_PREFIXES) {
                         doTestInvalidAttrName(true, prefix, name);
                         doTestInvalidAttrName(true, null, name);
                     }
                 }
             } else {
-                for (int i = 0; i < INVALID_NON_NS_NAMES.length; ++i) {
-                    String name = INVALID_NON_NS_NAMES[i];
+                for (String name : INVALID_NON_NS_NAMES) {
                     doTestInvalidAttrName(false, null, name);
                 }
             }
@@ -319,8 +307,7 @@ public class TestNameValidation
             /* No colons allowed in namespace-aware mode
              */
             String[] strs = ns ? VALID_NS_NAMES : VALID_NON_NS_NAMES;
-            for (int i = 0; i < strs.length; ++i) {
-                String name = strs[i];
+            for (String name : strs) {
                 sw.writeProcessingInstruction(name);
                 sw.writeProcessingInstruction(name, PI_DATA);
             }
@@ -338,11 +325,9 @@ public class TestNameValidation
             boolean empty = ((n & 2) == 0);
             String[] strs = ns ? INVALID_NS_NAMES : INVALID_NON_NS_NAMES;
 
-            for (int i = 0; i < strs.length; ++i) {
-                String name = strs[i];
+            for (String name : strs) {
                 XMLStreamWriter sw = startDoc(true, ns);
                 sw.writeStartElement("dummy");
-
 
                 try {
                     if (empty) {
@@ -375,9 +360,8 @@ public class TestNameValidation
             boolean validate = ((n & 2) == 0);
 
             String[] strs = ns ? VALID_NS_ROOT_NAMES : VALID_NON_NS_NAMES;
-            for (int i = 0; i < strs.length; ++i) {
-                XMLStreamWriter2 sw = (XMLStreamWriter2)startDoc(validate, ns);
-                String rootName = strs[i];
+            for (String rootName : strs) {
+                XMLStreamWriter2 sw = (XMLStreamWriter2) startDoc(validate, ns);
                 // only root name is mandatory, others are optional
                 sw.writeDTD(rootName, null, null, null);
                 // need a matching root, then:
@@ -405,9 +389,8 @@ public class TestNameValidation
             boolean ns = ((n & 1) == 0);
             String[] strs = ns ? INVALID_NS_ROOT_NAMES : INVALID_NON_NS_NAMES;
 
-            for (int i = 0; i < strs.length; ++i) {
-                String rootName = strs[i];
-                XMLStreamWriter2 sw = (XMLStreamWriter2)startDoc(true, ns);
+            for (String rootName : strs) {
+                XMLStreamWriter2 sw = (XMLStreamWriter2) startDoc(true, ns);
                 try {
                     // only root name is mandatory, others are optional
                     sw.writeDTD(rootName, null, null, null);
@@ -444,8 +427,7 @@ public class TestNameValidation
             /* No colons allowed in namespace-aware mode
              */
             String[] strs = ns ? VALID_NS_NAMES : VALID_NON_NS_NAMES;
-            for (int i = 0; i < strs.length; ++i) {
-                String name = strs[i];
+            for (String name : strs) {
                 sw.writeEntityRef(name);
             }
 
@@ -461,9 +443,8 @@ public class TestNameValidation
             boolean ns = ((n & 1) == 0);
             String[] strs = ns ? INVALID_NS_ROOT_NAMES : INVALID_NON_NS_NAMES;
 
-            for (int i = 0; i < strs.length; ++i) {
-                String name = strs[i];
-                XMLStreamWriter2 sw = (XMLStreamWriter2)startDoc(true, ns);
+            for (String name : strs) {
+                XMLStreamWriter2 sw = (XMLStreamWriter2) startDoc(true, ns);
                 sw.writeStartElement("dummy");
                 try {
                     // only root name is mandatory, others are optional

--- a/src/test/java/wstxtest/wstream/TestOptions.java
+++ b/src/test/java/wstxtest/wstream/TestOptions.java
@@ -44,11 +44,11 @@ public class TestOptions
             }
 
             if (space) {
-                if (str.indexOf("<root />") < 0) {
+                if (!str.contains("<root />")) {
                     fail("Expected '<root />' when space is to be added: got '"+str+"'");
                 }
             } else {
-                if (str.indexOf("<root/>") < 0) {
+                if (!str.contains("<root/>")) {
                     fail("Expected '<root />' when space is NOT to be added: got '"+str+"'");
                 }
             }
@@ -59,8 +59,7 @@ public class TestOptions
         throws IOException, XMLStreamException
     {
         XMLOutputFactory f = getOutputFactory();
-        f.setProperty(WstxOutputProperties.P_ADD_SPACE_AFTER_EMPTY_ELEM,
-                      Boolean.valueOf(addSpace));
+        f.setProperty(WstxOutputProperties.P_ADD_SPACE_AFTER_EMPTY_ELEM, addSpace);
         if (sw != null) {
             return f.createXMLStreamWriter(sw);
         }


### PR DESCRIPTION
e.g.,
* use for-each loops
* use lambdas/method references
* use `StringBuilder` instead of `StringBuffer`
* use auto-(un)boxing instead of `Boolean.valueOf()` / `...booleanValue()` etc. (performance impact not relevant in tests)
