### PR TITLE
Reject overlong UTF-8 sequences in `UTF8Reader`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -174,3 +174,8 @@ Nektarios Kitsios (@nektarios-kitsios)
 * Reported, contributed fix for #184: Notations declared in external
   DTD subsets reported as undefined
  (7.2.0)
+
+Aizal Khan (@aizu-m)
+
+* Contributed fix #291: Reject overlong UTF-8 sequences in `UTF8Reader`
+ (7.2.1)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -4,6 +4,11 @@ Project: woodstox
 === Releases ===
 ------------------------------------------------------------------------
 
+7.2.1 (not yet released)
+
+#291: Reject overlong UTF-8 sequences in `UTF8Reader`
+ (contributed by @aizu-m)
+
 7.2.0 (19-May-2026)
 
 #12: Improve hashing implementation used for symbol tables for element

--- a/src/main/java/com/ctc/wstx/io/UTF8Reader.java
+++ b/src/main/java/com/ctc/wstx/io/UTF8Reader.java
@@ -226,7 +226,8 @@ public final class UTF8Reader
                         reportInvalid(c, outPtr-start,
                                       "(above "+Integer.toHexString(XmlConsts.MAX_UNICODE_CHAR)+") ");
                     }
-                    // Reject overlong forms: 4-byte sequences must encode 0x10000 or higher
+                    // 01-Jun-2026: [woodstox#291]) Reject overlong forms: 4-byte sequences
+                    //  must encode 0x10000 or higher
                     if (c < 0x10000) {
                         reportInvalid(c, outPtr-start, "(overlong 4-byte UTF-8 encoding) ");
                     }
@@ -250,7 +251,8 @@ public final class UTF8Reader
                      * legal ones (should not expand to surrogates;
                      * 0xFFFE and 0xFFFF are illegal)
                      */
-                    // Reject overlong forms: 3-byte sequences must encode 0x800 or higher
+                    // 01-Jun-2026: [woodstox#291]) Reject overlong forms: 3-byte sequences
+                    //  must encode 0x800 or higher
                     if (c < 0x800) {
                         reportInvalid(c, outPtr-start, "(overlong 3-byte UTF-8 encoding) ");
                     }
@@ -275,7 +277,8 @@ public final class UTF8Reader
                     }
                 }
             } else { // (needed == 1)
-                // Reject overlong forms: 2-byte sequences must encode 0x80 or higher
+                // 01-Jun-2026: [woodstox#291]) Reject overlong forms: 2-byte sequences
+                //  must encode 0x80 or higher
                 if (c < 0x80) {
                     reportInvalid(c, outPtr-start, "(overlong 2-byte UTF-8 encoding) ");
                 }
@@ -317,8 +320,8 @@ public final class UTF8Reader
         int charPos = mCharCount + offset + 1;
 
         throw new CharConversionException("Invalid UTF-8 start byte 0x"
-                                          +Integer.toHexString(mask)
-                                          +" (at char #"+charPos+", byte #"+bytePos+")");
+                +Integer.toHexString(mask)
+                +" (at char #"+charPos+", byte #"+bytePos+")");
     }
 
     private void reportInvalidOther(int mask, int offset)
@@ -328,8 +331,8 @@ public final class UTF8Reader
         int charPos = mCharCount + offset;
 
         throw new CharConversionException("Invalid UTF-8 middle byte 0x"
-                                          +Integer.toHexString(mask)
-                                          +" (at char #"+charPos+", byte #"+bytePos+")");
+                +Integer.toHexString(mask)
+                +" (at char #"+charPos+", byte #"+bytePos+")");
     }
 
     private void reportUnexpectedEOF(int gotBytes, int needed)
@@ -339,8 +342,8 @@ public final class UTF8Reader
         int charPos = mCharCount;
 
         throw new CharConversionException("Unexpected EOF in the middle of a multi-byte char: got "
-                                          +gotBytes+", needed "+needed
-                                          +", at char #"+charPos+", byte #"+bytePos+")");
+                +gotBytes+", needed "+needed
+                +", at char #"+charPos+", byte #"+bytePos+")");
     }
 
     private void reportInvalid(int value, int offset, String msg)
@@ -350,8 +353,8 @@ public final class UTF8Reader
         int charPos = mCharCount + offset;
 
         throw new CharConversionException("Invalid UTF-8 character 0x"
-                                          +Integer.toHexString(value)+msg
-                                          +" at char #"+charPos+", byte #"+bytePos+")");
+                +Integer.toHexString(value)+msg
+                +" at char #"+charPos+", byte #"+bytePos+")");
     }
 
     /**

--- a/src/main/java/com/ctc/wstx/io/UTF8Reader.java
+++ b/src/main/java/com/ctc/wstx/io/UTF8Reader.java
@@ -226,6 +226,10 @@ public final class UTF8Reader
                         reportInvalid(c, outPtr-start,
                                       "(above "+Integer.toHexString(XmlConsts.MAX_UNICODE_CHAR)+") ");
                     }
+                    // Reject overlong forms: 4-byte sequences must encode 0x10000 or higher
+                    if (c < 0x10000) {
+                        reportInvalid(c, outPtr-start, "(overlong 4-byte UTF-8 encoding) ");
+                    }
                     /* Ugh. Need to mess with surrogates. Ok; let's inline them
                      * there, then, if there's room: if only room for one,
                      * need to save the surrogate for the rainy day...
@@ -246,6 +250,10 @@ public final class UTF8Reader
                      * legal ones (should not expand to surrogates;
                      * 0xFFFE and 0xFFFF are illegal)
                      */
+                    // Reject overlong forms: 3-byte sequences must encode 0x800 or higher
+                    if (c < 0x800) {
+                        reportInvalid(c, outPtr-start, "(overlong 3-byte UTF-8 encoding) ");
+                    }
                     if (c >= 0xD800) {
                         // But first, let's check max chars:
                         if (c < 0xE000) {
@@ -267,6 +275,10 @@ public final class UTF8Reader
                     }
                 }
             } else { // (needed == 1)
+                // Reject overlong forms: 2-byte sequences must encode 0x80 or higher
+                if (c < 0x80) {
+                    reportInvalid(c, outPtr-start, "(overlong 2-byte UTF-8 encoding) ");
+                }
                 if (xml11) { // high-order ctrl char detection...
                     if (c <= 0x9F) {
                         if (c == 0x85) { // NEL, let's convert?

--- a/src/main/java/com/ctc/wstx/io/UTF8Reader.java
+++ b/src/main/java/com/ctc/wstx/io/UTF8Reader.java
@@ -226,7 +226,7 @@ public final class UTF8Reader
                         reportInvalid(c, outPtr-start,
                                       "(above "+Integer.toHexString(XmlConsts.MAX_UNICODE_CHAR)+") ");
                     }
-                    // 01-Jun-2026: [woodstox#291]) Reject overlong forms: 4-byte sequences
+                    // 01-Jun-2026: [woodstox#291] Reject overlong forms: 4-byte sequences
                     //  must encode 0x10000 or higher
                     if (c < 0x10000) {
                         reportInvalid(c, outPtr-start, "(overlong 4-byte UTF-8 encoding) ");
@@ -251,7 +251,7 @@ public final class UTF8Reader
                      * legal ones (should not expand to surrogates;
                      * 0xFFFE and 0xFFFF are illegal)
                      */
-                    // 01-Jun-2026: [woodstox#291]) Reject overlong forms: 3-byte sequences
+                    // 01-Jun-2026: [woodstox#291] Reject overlong forms: 3-byte sequences
                     //  must encode 0x800 or higher
                     if (c < 0x800) {
                         reportInvalid(c, outPtr-start, "(overlong 3-byte UTF-8 encoding) ");
@@ -277,7 +277,7 @@ public final class UTF8Reader
                     }
                 }
             } else { // (needed == 1)
-                // 01-Jun-2026: [woodstox#291]) Reject overlong forms: 2-byte sequences
+                // 01-Jun-2026: [woodstox#291] Reject overlong forms: 2-byte sequences
                 //  must encode 0x80 or higher
                 if (c < 0x80) {
                     reportInvalid(c, outPtr-start, "(overlong 2-byte UTF-8 encoding) ");

--- a/src/test/java/wstxtest/io/TestUTF8Reader.java
+++ b/src/test/java/wstxtest/io/TestUTF8Reader.java
@@ -3,16 +3,16 @@ package wstxtest.io;
 import java.io.*;
 import java.util.Arrays;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
 import com.ctc.wstx.api.ReaderConfig;
 import com.ctc.wstx.io.UTF8Reader;
-import org.junit.jupiter.api.Test;
 
 /**
  * Unit test created to verify fix to
- * <a href="http://jira.codehaus.org/browse/WSTX-143">WSTX-143</a>.
+ * <a href="http://jira.codehaus.org/browse/WSTX-143">WSTX-143</a>
+ * and
+ * <a href="https://github.com/FasterXML/woodstox/pull/291/">woodstox#291</a>.
  *
  * @author Matt Gormley
  */
@@ -20,32 +20,32 @@ public class TestUTF8Reader extends wstxtest.BaseJUnit4Test
 {
     @SuppressWarnings("resource")
     @Test
-    public void testDelAtBufferBoundary() throws IOException
+    public void testDelAtBufferBoundary() throws Exception
     {
-	final int BYTE_BUFFER_SIZE = 4;
-	final int CHAR_BUFFER_SIZE = 1 + BYTE_BUFFER_SIZE; 
-	final int INPUT_SIZE = 4 * BYTE_BUFFER_SIZE; // could be of arbitrary size
-	final byte CHAR_FILLER = 32; // doesn't even matter, just need an ascii char
-	final byte CHAR_DEL = 127;
-	
-	// Create input that will cause the array index out of bounds exception
-	byte[] inputBytes = new byte[INPUT_SIZE];
-	Arrays.fill(inputBytes, CHAR_FILLER);
-	inputBytes[BYTE_BUFFER_SIZE - 1] = CHAR_DEL;
-	InputStream in = new ByteArrayInputStream(inputBytes);
-	
-	// Create the UTF8Reader
-	ReaderConfig cfg = ReaderConfig.createFullDefaults();
-	byte[] byteBuffer = new byte[BYTE_BUFFER_SIZE];
-	UTF8Reader reader = new UTF8Reader(cfg,in, byteBuffer, 0, 0, false);
-	
-	// Run the reader on the input
-	char[] charBuffer = new char[CHAR_BUFFER_SIZE];
-	reader.read(charBuffer, 0, charBuffer.length);
+        final int BYTE_BUFFER_SIZE = 4;
+        final int CHAR_BUFFER_SIZE = 1 + BYTE_BUFFER_SIZE; 
+        final int INPUT_SIZE = 4 * BYTE_BUFFER_SIZE; // could be of arbitrary size
+        final byte CHAR_FILLER = 32; // doesn't even matter, just need an ascii char
+        final byte CHAR_DEL = 127;
+
+        // Create input that will cause the array index out of bounds exception
+        byte[] inputBytes = new byte[INPUT_SIZE];
+        Arrays.fill(inputBytes, CHAR_FILLER);
+        inputBytes[BYTE_BUFFER_SIZE - 1] = CHAR_DEL;
+        InputStream in = new ByteArrayInputStream(inputBytes);
+
+        // Create the UTF8Reader
+        ReaderConfig cfg = ReaderConfig.createFullDefaults();
+        byte[] byteBuffer = new byte[BYTE_BUFFER_SIZE];
+        UTF8Reader reader = new UTF8Reader(cfg,in, byteBuffer, 0, 0, false);
+
+        // Run the reader on the input
+        char[] charBuffer = new char[CHAR_BUFFER_SIZE];
+        reader.read(charBuffer, 0, charBuffer.length);
     }
 
     @Test
-    public void testOverlongEncodingsRejected() throws IOException
+    public void testOverlongEncodingsRejected() throws Exception
     {
         // Overlong forms decode to a codepoint below the minimum for their
         // byte length; these must be rejected as malformed (RFC 3629)
@@ -63,7 +63,7 @@ public class TestUTF8Reader extends wstxtest.BaseJUnit4Test
     }
 
     @SuppressWarnings("resource")
-    private static String decode(byte[] input) throws IOException
+    private static String decode(byte[] input) throws Exception
     {
         ReaderConfig cfg = ReaderConfig.createFullDefaults();
         UTF8Reader reader = new UTF8Reader(cfg, new ByteArrayInputStream(input),
@@ -73,7 +73,7 @@ public class TestUTF8Reader extends wstxtest.BaseJUnit4Test
         return new String(cbuf, 0, count);
     }
 
-    private static void assertRejected(byte[] input) throws IOException
+    private static void assertRejected(byte[] input) throws Exception
     {
         try {
             decode(input);

--- a/src/test/java/wstxtest/io/TestUTF8Reader.java
+++ b/src/test/java/wstxtest/io/TestUTF8Reader.java
@@ -3,6 +3,8 @@ package wstxtest.io;
 import java.io.*;
 import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.ctc.wstx.api.ReaderConfig;
 import com.ctc.wstx.io.UTF8Reader;
@@ -39,6 +41,45 @@ public class TestUTF8Reader extends wstxtest.BaseJUnit4Test
 	
 	// Run the reader on the input
 	char[] charBuffer = new char[CHAR_BUFFER_SIZE];
-	reader.read(charBuffer, 0, charBuffer.length);		
+	reader.read(charBuffer, 0, charBuffer.length);
+    }
+
+    @Test
+    public void testOverlongEncodingsRejected() throws IOException
+    {
+        // Overlong forms decode to a codepoint below the minimum for their
+        // byte length; these must be rejected as malformed (RFC 3629)
+        assertRejected(new byte[]{(byte)0xC0,(byte)0xBC}); // overlong '<'
+        assertRejected(new byte[]{(byte)0xC0,(byte)0x80}); // overlong NUL
+        assertRejected(new byte[]{(byte)0xE0,(byte)0x80,(byte)0xAF}); // overlong '/'
+        assertRejected(new byte[]{(byte)0xF0,(byte)0x80,(byte)0x81,(byte)0x81}); // overlong 4-byte
+
+        // Shortest (valid) forms for the same boundaries must still decode
+        assertEquals("<", decode(new byte[]{(byte)0x3C}));
+        assertEquals("é", decode(new byte[]{(byte)0xC3,(byte)0xA9}));
+        assertEquals("€", decode(new byte[]{(byte)0xE2,(byte)0x82,(byte)0xAC}));
+        assertEquals(new String(Character.toChars(0x1F600)),
+                decode(new byte[]{(byte)0xF0,(byte)0x9F,(byte)0x98,(byte)0x80}));
+    }
+
+    @SuppressWarnings("resource")
+    private static String decode(byte[] input) throws IOException
+    {
+        ReaderConfig cfg = ReaderConfig.createFullDefaults();
+        UTF8Reader reader = new UTF8Reader(cfg, new ByteArrayInputStream(input),
+                new byte[16], 0, 0, false);
+        char[] cbuf = new char[16];
+        int count = reader.read(cbuf, 0, cbuf.length);
+        return new String(cbuf, 0, count);
+    }
+
+    private static void assertRejected(byte[] input) throws IOException
+    {
+        try {
+            decode(input);
+            fail("Expected CharConversionException for overlong UTF-8 sequence");
+        } catch (CharConversionException e) {
+            // expected
+        }
     }
 }

--- a/src/test/java/wstxtest/io/TestUTF8Reader.java
+++ b/src/test/java/wstxtest/io/TestUTF8Reader.java
@@ -23,7 +23,7 @@ public class TestUTF8Reader extends wstxtest.BaseJUnit4Test
     public void testDelAtBufferBoundary() throws Exception
     {
         final int BYTE_BUFFER_SIZE = 4;
-        final int CHAR_BUFFER_SIZE = 1 + BYTE_BUFFER_SIZE; 
+        final int CHAR_BUFFER_SIZE = 1 + BYTE_BUFFER_SIZE;
         final int INPUT_SIZE = 4 * BYTE_BUFFER_SIZE; // could be of arbitrary size
         final byte CHAR_FILLER = 32; // doesn't even matter, just need an ascii char
         final byte CHAR_DEL = 127;
@@ -62,6 +62,16 @@ public class TestUTF8Reader extends wstxtest.BaseJUnit4Test
                 decode(new byte[]{(byte)0xF0,(byte)0x9F,(byte)0x98,(byte)0x80}));
     }
 
+    private static void assertRejected(byte[] input) throws Exception
+    {
+        try {
+            decode(input);
+            fail("Expected CharConversionException for overlong UTF-8 sequence");
+        } catch (CharConversionException e) {
+            // expected
+        }
+    }
+
     @SuppressWarnings("resource")
     private static String decode(byte[] input) throws Exception
     {
@@ -71,15 +81,5 @@ public class TestUTF8Reader extends wstxtest.BaseJUnit4Test
         char[] cbuf = new char[16];
         int count = reader.read(cbuf, 0, cbuf.length);
         return new String(cbuf, 0, count);
-    }
-
-    private static void assertRejected(byte[] input) throws Exception
-    {
-        try {
-            decode(input);
-            fail("Expected CharConversionException for overlong UTF-8 sequence");
-        } catch (CharConversionException e) {
-            // expected
-        }
     }
 }


### PR DESCRIPTION
UTF8Reader.read() assembles multi-byte sequences but never checks they use the shortest form, so overlong encodings decode instead of erroring: C0 BC yields "<", C0 80 yields NUL, E0 80 AF yields "/", and the overlong 4-byte form falls into the surrogate split and emits a bogus pair. RFC 3629 requires treating non-shortest forms as malformed.

Add a minimum-codepoint check at each of the three multi-byte sites (>=0x80, >=0x800, >=0x10000), reusing the existing reportInvalid path next to the surrogate and over-max checks.