### PR TITLE
Reject out-of-range code points in `UTF32Reader`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -179,3 +179,5 @@ Aizal Khan (@aizu-m)
 
 * Contributed fix #291: Reject overlong UTF-8 sequences in `UTF8Reader`
  (7.2.1)
+* Contributed fix #293: Reject out-of-range code points in `UTF32Reader`
+ (7.2.1)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -8,6 +8,8 @@ Project: woodstox
 
 #291: Reject overlong UTF-8 sequences in `UTF8Reader`
  (contributed by @aizu-m)
+#293: Reject out-of-range code points in `UTF32Reader`
+ (contributed by @aizu-m)
 
 7.2.0 (19-May-2026)
 

--- a/src/main/java/com/ctc/wstx/io/UTF32Reader.java
+++ b/src/main/java/com/ctc/wstx/io/UTF32Reader.java
@@ -131,6 +131,14 @@ public final class UTF32Reader
             }
             mBytePtr += 4;
 
+            // Any code point above the Unicode max is illegal; note that a
+            // negative value here means the high byte's top bit was set, which
+            // sign-extends into an out-of-range value rather than a valid char.
+            if (ch < 0 || ch > XmlConsts.MAX_UNICODE_CHAR) {
+                reportInvalid(ch, outPtr-start,
+                              "(above "+Integer.toHexString(XmlConsts.MAX_UNICODE_CHAR)+") ");
+            }
+
             // Does it need to be split to surrogates?
             // (also, we can and need to verify illegal chars)
             if (ch >= 0x7F) {
@@ -142,11 +150,6 @@ public final class UTF32Reader
                         ch = CONVERT_NEL_TO;
                     }
                 } else if (ch >= 0xD800) {
-                    // Illegal?
-                    if (ch > XmlConsts.MAX_UNICODE_CHAR) {
-                        reportInvalid(ch, outPtr-start,
-                                      "(above "+Integer.toHexString(XmlConsts.MAX_UNICODE_CHAR)+") ");
-                    }
                     if (ch > 0xFFFF) { // need to split into surrogates?
                         ch -= 0x10000; // to normalize it starting with 0x0
                         cbuf[outPtr++] = (char) (0xD800 + (ch >> 10));

--- a/src/main/java/com/ctc/wstx/io/UTF32Reader.java
+++ b/src/main/java/com/ctc/wstx/io/UTF32Reader.java
@@ -49,9 +49,9 @@ public final class UTF32Reader
     protected int mByteCount = 0;
 
     /*
-    ////////////////////////////////////////
+    ///////////////////////////////////////////////////////////
     // Life-cycle
-    ////////////////////////////////////////
+    ///////////////////////////////////////////////////////////
     */
 
     public UTF32Reader(ReaderConfig cfg, InputStream in, byte[] buf, int ptr, int len,
@@ -67,9 +67,9 @@ public final class UTF32Reader
     }
 
     /*
-    ////////////////////////////////////////
+    ///////////////////////////////////////////////////////////
     // Public API
-    ////////////////////////////////////////
+    ///////////////////////////////////////////////////////////
     */
 
     @Override
@@ -140,7 +140,8 @@ public final class UTF32Reader
             }
 
             // Does it need to be split to surrogates?
-            // (also, we can and need to verify illegal chars)
+            // (also, we still verify remaining illegal chars here, such as
+            // surrogate code points and 0xFFFE/0xFFFF)
             if (ch >= 0x7F) {
                 if (ch <= 0x9F) {
                     if (mXml11) { // high-order ctrl char detection...
@@ -180,9 +181,9 @@ public final class UTF32Reader
     }
 
     /*
-    ////////////////////////////////////////
+    ///////////////////////////////////////////////////////////
     // Internal methods
-    ////////////////////////////////////////
+    ///////////////////////////////////////////////////////////
     */
 
     private void reportUnexpectedEOF(int gotBytes, int needed)
@@ -258,4 +259,3 @@ public final class UTF32Reader
         return true;
     }
 }
-

--- a/src/test/java/wstxtest/fuzz/Fuzz125_32969_UTF32ReadTest.java
+++ b/src/test/java/wstxtest/fuzz/Fuzz125_32969_UTF32ReadTest.java
@@ -35,7 +35,10 @@ public class Fuzz125_32969_UTF32ReadTest extends BaseStreamTest
             streamThrough(sr);
             fail("Should not pass");
         } catch (WstxIOException e) {
-            verifyException(e, "Unexpected EOF in the middle of a 4-byte UTF-32 char");
+            // 02-Jun-2026, [woodstox-core#293]: out-of-range code point (high
+            //   byte top bit set, sign-extends negative) is now rejected up
+            //   front instead of being truncated and slipping through to EOF.
+            verifyException(e, "Invalid UTF-32 character");
         }
         sr.close();
     }
@@ -51,7 +54,8 @@ public class Fuzz125_32969_UTF32ReadTest extends BaseStreamTest
             streamThrough(sr);
             fail("Should not pass");
         } catch (WstxIOException e) {
-            verifyException(e, "Unexpected EOF in the middle of a 4-byte UTF-32 char");
+            // 02-Jun-2026, [woodstox-core#293]: see above
+            verifyException(e, "Invalid UTF-32 character");
         }
         sr.close();
     }

--- a/src/test/java/wstxtest/io/TestUTF32Reader.java
+++ b/src/test/java/wstxtest/io/TestUTF32Reader.java
@@ -1,0 +1,50 @@
+package wstxtest.io;
+
+import java.io.*;
+
+import com.ctc.wstx.api.ReaderConfig;
+import com.ctc.wstx.io.UTF32Reader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestUTF32Reader extends wstxtest.BaseJUnit4Test
+{
+    @SuppressWarnings("resource")
+    private UTF32Reader reader(byte[] input, boolean bigEndian) {
+        ReaderConfig cfg = ReaderConfig.createFullDefaults();
+        return new UTF32Reader(cfg, new ByteArrayInputStream(input),
+                new byte[16], 0, 0, false, bigEndian);
+    }
+
+    // Code points above U+10FFFF must be rejected, not truncated to 16 bits.
+    // The high byte's top bit sign-extends the int negative, which previously
+    // slipped past the range checks and decoded e.g. 80 00 00 3C to '<'.
+    @Test
+    public void testOutOfRangeBigEndian() throws IOException {
+        try {
+            int n = reader(new byte[]{(byte)0x80, 0x00, 0x00, 0x3C}, true)
+                    .read(new char[8], 0, 8);
+            fail("Expected CharConversionException, got "+n+" char(s)");
+        } catch (CharConversionException expected) { }
+    }
+
+    @Test
+    public void testOutOfRangeLittleEndian() throws IOException {
+        try {
+            int n = reader(new byte[]{0x3C, 0x00, 0x00, (byte)0x80}, false)
+                    .read(new char[8], 0, 8);
+            fail("Expected CharConversionException, got "+n+" char(s)");
+        } catch (CharConversionException expected) { }
+    }
+
+    // Legal astral character (U+10000) still decodes to a surrogate pair.
+    @Test
+    public void testValidAstral() throws IOException {
+        char[] cbuf = new char[8];
+        int n = reader(new byte[]{0x00, 0x01, 0x00, 0x00}, true).read(cbuf, 0, 8);
+        assertEquals(2, n);
+        assertEquals('\uD800', cbuf[0]);
+        assertEquals('\uDC00', cbuf[1]);
+    }
+}

--- a/src/test/java/wstxtest/io/TestUTF32Reader.java
+++ b/src/test/java/wstxtest/io/TestUTF32Reader.java
@@ -2,11 +2,10 @@ package wstxtest.io;
 
 import java.io.*;
 
-import com.ctc.wstx.api.ReaderConfig;
-import com.ctc.wstx.io.UTF32Reader;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import com.ctc.wstx.api.ReaderConfig;
+import com.ctc.wstx.io.UTF32Reader;
 
 public class TestUTF32Reader extends wstxtest.BaseJUnit4Test
 {
@@ -21,7 +20,7 @@ public class TestUTF32Reader extends wstxtest.BaseJUnit4Test
     // The high byte's top bit sign-extends the int negative, which previously
     // slipped past the range checks and decoded e.g. 80 00 00 3C to '<'.
     @Test
-    public void testOutOfRangeBigEndian() throws IOException {
+    public void testOutOfRangeBigEndian() throws Exception {
         try {
             int n = reader(new byte[]{(byte)0x80, 0x00, 0x00, 0x3C}, true)
                     .read(new char[8], 0, 8);
@@ -30,7 +29,7 @@ public class TestUTF32Reader extends wstxtest.BaseJUnit4Test
     }
 
     @Test
-    public void testOutOfRangeLittleEndian() throws IOException {
+    public void testOutOfRangeLittleEndian() throws Exception {
         try {
             int n = reader(new byte[]{0x3C, 0x00, 0x00, (byte)0x80}, false)
                     .read(new char[8], 0, 8);
@@ -40,7 +39,7 @@ public class TestUTF32Reader extends wstxtest.BaseJUnit4Test
 
     // Legal astral character (U+10000) still decodes to a surrogate pair.
     @Test
-    public void testValidAstral() throws IOException {
+    public void testValidAstral() throws Exception {
         char[] cbuf = new char[8];
         int n = reader(new byte[]{0x00, 0x01, 0x00, 0x00}, true).read(cbuf, 0, 8);
         assertEquals(2, n);


### PR DESCRIPTION
Noticed UTF32Reader.read assembles a 4-byte unit into a signed int, so when the high byte's top bit is set the value sign-extends negative and slips past the surrogate/MAX_UNICODE_CHAR checks before being truncated by the `(char)` cast. Bytes `80 00 00 3C` (a code point well above U+10FFFF) decode to '<' instead of failing. Reject `ch < 0 || ch > MAX_UNICODE_CHAR` right after the unit is read, covering both endian branches.