### PR TITLE
Fix #292: Text corruption with `WstxInputProperties.P_TREAT_CHAR_REFS_AS_ENTS` ("com.ctc.wstx.treatCharRefsAsEnts") enabled

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -181,3 +181,9 @@ Aizal Khan (@aizu-m)
  (7.2.1)
 * Contributed fix #293: Reject out-of-range code points in `UTF32Reader`
  (7.2.1)
+
+@Skrethel
+
+* Reported #292: Text corruption with `doTreatCharRefsAsEnts` enabled when a
+  character reference is split across the internal input buffer boundary
+ (7.2.1)

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -182,8 +182,9 @@ Aizal Khan (@aizu-m)
 * Contributed fix #293: Reject out-of-range code points in `UTF32Reader`
  (7.2.1)
 
-@Skrethel
+Skrethel (@Skrethel)
 
-* Reported #292: Text corruption with `doTreatCharRefsAsEnts` enabled when a
-  character reference is split across the internal input buffer boundary
+* Reported #292: Text corruption (in element content and attribute values)
+  with `doTreatCharRefsAsEnts` enabled when a character reference is split
+  across the internal input buffer boundary
  (7.2.1)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -8,8 +8,9 @@ Project: woodstox
 
 #291: Reject overlong UTF-8 sequences in `UTF8Reader`
  (contributed by @aizu-m)
-#292: Text corruption with `doTreatCharRefsAsEnts` enabled when a character
-  reference is split across the internal input buffer boundary
+#292: Text corruption (in element content and attribute values) with
+  `doTreatCharRefsAsEnts` enabled when a character reference is split across
+  the internal input buffer boundary
  (reported by @Skrethel)
 #293: Reject out-of-range code points in `UTF32Reader`
  (contributed by @aizu-m)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -8,6 +8,9 @@ Project: woodstox
 
 #291: Reject overlong UTF-8 sequences in `UTF8Reader`
  (contributed by @aizu-m)
+#292: Text corruption with `doTreatCharRefsAsEnts` enabled when a character
+  reference is split across the internal input buffer boundary
+ (reported by @Skrethel)
 #293: Reject out-of-range code points in `UTF32Reader`
  (contributed by @aizu-m)
 

--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -4852,9 +4852,25 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                             && (ch = resolveSimpleEntity(true)) != 0) {
                             // Ok, it's fine then
                         } else {
+                            final WstxInputSource currInput = mInput;
                             ch = fullyResolveEntity(true);
                             if (ch == 0) {
-                                // Input buffer changed, nothing to output quite yet:
+                                // 02-Jun-2026, tatu: [woodstox-core#292] With
+                                //   `doTreatCharRefsAsEnts`, char refs and pre-defined
+                                //   entities get resolved into an internal entity
+                                //   (`mCurrEntity`) and 0 returned, WITHOUT pushing a
+                                //   new input source. Mid-segment we can not emit a
+                                //   separate ENTITY_REFERENCE event, so the replacement
+                                //   text must be output here (as the in-buffer fast path
+                                //   above does); otherwise the character would be lost.
+                                if (mInput == currInput && mCurrEntity != null) {
+                                    mTextBuffer.setCurrentLength(outPtr);
+                                    mTextBuffer.append(mCurrEntity.getReplacementText());
+                                    mCurrEntity = null;
+                                    outBuf = mTextBuffer.getCurrentSegment();
+                                    outPtr = mTextBuffer.getCurrentSegmentSize();
+                                }
+                                // Input buffer changed, nothing (more) to output quite yet:
                                 inputBuffer = mInputBuffer;
                                 inputLen = mInputEnd;
                                 inputPtr = mInputPtr;
@@ -5302,7 +5318,19 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                     if (mCfgReplaceEntities) { // can we expand all entities?
                         if ((mInputEnd - mInputPtr) < 3
                             || (ch = resolveSimpleEntity(true)) == 0) {
+                            final WstxInputSource currInput = mInput;
                             ch = fullyResolveEntity(true);
+                            // 02-Jun-2026, tatu: [woodstox-core#292] With
+                            //   `doTreatCharRefsAsEnts`, char refs / pre-defined
+                            //   entities resolve into an internal entity without
+                            //   pushing a new input source; output their replacement
+                            //   text directly so it does not get lost.
+                            if (ch == 0 && mInput == currInput && mCurrEntity != null) {
+                                String repl = mCurrEntity.getReplacementText();
+                                mCurrEntity = null;
+                                w.write(repl);
+                                count += repl.length();
+                            }
                         }
                     } else {
                         ch = resolveCharOnlyEntity(true);

--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -2020,18 +2020,14 @@ public abstract class BasicStreamReader
                         // Ok, fine, c is whatever it is
                         ;
                     } else { // full entity just changes buffer...
-                        final WstxInputSource currInput = mInput;
+                        final WstxInputSource preInput = mInput;
                         ch = fullyResolveEntity(false);
                         if (ch == 0) {
-                            // 02-Jun-2026, tatu: [woodstox-core#292] With
-                            //   `doTreatCharRefsAsEnts`, char refs and pre-defined
-                            //   entities resolve into an internal entity
-                            //   (`mCurrEntity`) and 0 is returned, WITHOUT pushing a
-                            //   new input source. Their replacement chars must be
-                            //   output here, or they would be silently dropped.
-                            if (mInput == currInput && mCurrEntity != null) {
-                                char[] repl = mCurrEntity.getReplacementChars();
-                                mCurrEntity = null;
+                            // [woodstox-core#292] char-ref-as-entity: output its
+                            // replacement chars inline (else expanded to new input
+                            // source, nothing to output here)
+                            char[] repl = takeInlineCharRefReplacement(preInput);
+                            if (repl != null) {
                                 for (int i = 0, len = repl.length; i < len; ++i) {
                                     if (outPtr >= outLimit) {
                                         outBuf = _checkAttributeLimit(tb, outBuf, outPtr, outPtr - startingOffset, maxAttrSize);
@@ -2040,7 +2036,6 @@ public abstract class BasicStreamReader
                                     outBuf[outPtr++] = repl[i];
                                 }
                             }
-                            // expanded to new input source (or handled above): skip output
                             continue;
                         }
                     }
@@ -4870,21 +4865,17 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                             && (ch = resolveSimpleEntity(true)) != 0) {
                             // Ok, it's fine then
                         } else {
-                            final WstxInputSource currInput = mInput;
+                            final WstxInputSource preInput = mInput;
                             ch = fullyResolveEntity(true);
                             if (ch == 0) {
-                                // 02-Jun-2026, tatu: [woodstox-core#292] With
-                                //   `doTreatCharRefsAsEnts`, char refs and pre-defined
-                                //   entities get resolved into an internal entity
-                                //   (`mCurrEntity`) and 0 returned, WITHOUT pushing a
-                                //   new input source. Mid-segment we can not emit a
-                                //   separate ENTITY_REFERENCE event, so the replacement
-                                //   text must be output here (as the in-buffer fast path
-                                //   above does); otherwise the character would be lost.
-                                if (mInput == currInput && mCurrEntity != null) {
+                                // [woodstox-core#292] char-ref-as-entity: output its
+                                // replacement chars inline (mid-segment we can not emit
+                                // a separate ENTITY_REFERENCE event), as the in-buffer
+                                // fast path above does
+                                char[] repl = takeInlineCharRefReplacement(preInput);
+                                if (repl != null) {
                                     mTextBuffer.setCurrentLength(outPtr);
-                                    mTextBuffer.append(mCurrEntity.getReplacementText());
-                                    mCurrEntity = null;
+                                    mTextBuffer.append(repl, 0, repl.length);
                                     outBuf = mTextBuffer.getCurrentSegment();
                                     outPtr = mTextBuffer.getCurrentSegmentSize();
                                 }
@@ -4990,7 +4981,38 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
         // If not, need more buffer space:
         return tb.finishCurrentSegment();
     }
-    
+
+    /**
+     * Helper called after {@link #fullyResolveEntity} has returned 0 from within
+     * text or attribute content, to support [woodstox-core#292]: when
+     * {@code doTreatCharRefsAsEnts} is enabled, character references and pre-defined
+     * entities are resolved into an internal entity ({@link #mCurrEntity}) and 0 is
+     * returned <b>without</b> pushing a new input source. In that case their
+     * replacement characters must still be output inline by the caller -- mid-content
+     * a separate {@code ENTITY_REFERENCE} event can not be emitted -- or the
+     * referenced character would be silently dropped.
+     *<p>
+     * This "resolved inline" case is told apart from the "entered a new input source"
+     * case (where 0 also means "nothing to output here") by checking whether the
+     * current input source still matches the one active just before the
+     * {@code fullyResolveEntity} call.
+     *
+     * @param preResolveInput Value of {@link #mInput} captured immediately
+     *   <b>before</b> the {@code fullyResolveEntity} call
+     *
+     * @return Replacement characters to output inline, or {@code null} if nothing
+     *   is to be output here (a new input source was entered instead)
+     */
+    protected final char[] takeInlineCharRefReplacement(WstxInputSource preResolveInput)
+    {
+        if (mInput == preResolveInput && mCurrEntity != null) {
+            char[] repl = mCurrEntity.getReplacementChars();
+            mCurrEntity = null;
+            return repl;
+        }
+        return null;
+    }
+
     /**
      * Method called to try to parse and canonicalize white space that
      * has a good chance of being white space with somewhat regular
@@ -5336,18 +5358,16 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                     if (mCfgReplaceEntities) { // can we expand all entities?
                         if ((mInputEnd - mInputPtr) < 3
                             || (ch = resolveSimpleEntity(true)) == 0) {
-                            final WstxInputSource currInput = mInput;
+                            final WstxInputSource preInput = mInput;
                             ch = fullyResolveEntity(true);
-                            // 02-Jun-2026, tatu: [woodstox-core#292] With
-                            //   `doTreatCharRefsAsEnts`, char refs / pre-defined
-                            //   entities resolve into an internal entity without
-                            //   pushing a new input source; output their replacement
-                            //   text directly so it does not get lost.
-                            if (ch == 0 && mInput == currInput && mCurrEntity != null) {
-                                String repl = mCurrEntity.getReplacementText();
-                                mCurrEntity = null;
-                                w.write(repl);
-                                count += repl.length();
+                            if (ch == 0) {
+                                // [woodstox-core#292] char-ref-as-entity: write its
+                                // replacement chars directly so they are not lost
+                                char[] repl = takeInlineCharRefReplacement(preInput);
+                                if (repl != null) {
+                                    w.write(repl, 0, repl.length);
+                                    count += repl.length;
+                                }
                             }
                         }
                     } else {

--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -4888,14 +4888,12 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                             // otherwise char is now fine...
                         }
                     } else {
-                        /* Nope, can only expand char entities; others need
-                         * to be separately handled.
-                         */
+                        // Nope, can only expand char entities; others need
+                        // to be separately handled.
                         ch = resolveCharOnlyEntity(true);
                         if (ch == 0) { // some other entity...
-                            /* can't expand; underlying pointer now points to
-                             * char after ampersand, need to rewind
-                             */
+                            // can't expand; underlying pointer now points to
+                            // char after ampersand, need to rewind
                             --mInputPtr;
                             break;
                         }
@@ -5002,6 +5000,8 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
      *
      * @return Replacement characters to output inline, or {@code null} if nothing
      *   is to be output here (a new input source was entered instead)
+     *
+     * @since 7.2.1
      */
     protected final char[] takeInlineCharRefReplacement(WstxInputSource preResolveInput)
     {

--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -2020,9 +2020,27 @@ public abstract class BasicStreamReader
                         // Ok, fine, c is whatever it is
                         ;
                     } else { // full entity just changes buffer...
+                        final WstxInputSource currInput = mInput;
                         ch = fullyResolveEntity(false);
                         if (ch == 0) {
-                            // need to skip output, thusly (expanded to new input source)
+                            // 02-Jun-2026, tatu: [woodstox-core#292] With
+                            //   `doTreatCharRefsAsEnts`, char refs and pre-defined
+                            //   entities resolve into an internal entity
+                            //   (`mCurrEntity`) and 0 is returned, WITHOUT pushing a
+                            //   new input source. Their replacement chars must be
+                            //   output here, or they would be silently dropped.
+                            if (mInput == currInput && mCurrEntity != null) {
+                                char[] repl = mCurrEntity.getReplacementChars();
+                                mCurrEntity = null;
+                                for (int i = 0, len = repl.length; i < len; ++i) {
+                                    if (outPtr >= outLimit) {
+                                        outBuf = _checkAttributeLimit(tb, outBuf, outPtr, outPtr - startingOffset, maxAttrSize);
+                                        outLimit = _outputLimit(outBuf, startingOffset, maxAttrSize);
+                                    }
+                                    outBuf[outPtr++] = repl[i];
+                                }
+                            }
+                            // expanded to new input source (or handled above): skip output
                             continue;
                         }
                     }

--- a/src/test/java/wstxtest/stream/TestCharRefAsEntsSplit292.java
+++ b/src/test/java/wstxtest/stream/TestCharRefAsEntsSplit292.java
@@ -86,9 +86,16 @@ public class TestCharRefAsEntsSplit292 extends BaseStreamTest
 
     // getText() path, non-coalescing (multiple CHARACTERS segments).
     // Also asserts the token contract: with the default (high) min-text-segment,
-    // mid-content char refs are inlined into CHARACTERS, NOT emitted as separate
-    // ENTITY_REFERENCE events -- so a regression that flips inlining back into
-    // standalone entity events is caught, not masked by concatenation.
+    // mid-content char refs are inlined into CHARACTERS rather than systematically
+    // promoted to standalone ENTITY_REFERENCE events -- so a regression that flips
+    // inlining back into separate entity events is caught, not masked by
+    // concatenating both event types.
+    //
+    // Note: this is a "vast majority are inlined" assertion, not "exactly zero".
+    // A non-coalescing segment boundary can legitimately fall on a '&' (it is
+    // driven by output-buffer sizing, not content), making an occasional ref a
+    // standalone event with no data loss; only a wholesale flip (every ref) is a
+    // real regression, and that would push entityRefs to ~ENTITY_COUNT.
     @Test
     public void testNoCorruptionNonCoalescingGetText() throws Exception {
         for (int r = 0; r < REFS.length; ++r) {
@@ -110,9 +117,10 @@ public class TestCharRefAsEntsSplit292 extends BaseStreamTest
             if (chars < 1) {
                 fail("ref="+REFS[r]+": expected at least one CHARACTERS event");
             }
-            if (entityRefs != 0) {
-                fail("ref="+REFS[r]+": expected char refs to be inlined as CHARACTERS, "
-                        +"but got "+entityRefs+" ENTITY_REFERENCE event(s)");
+            // Tolerate incidental boundary-aligned events; catch a wholesale flip:
+            if (entityRefs >= ENTITY_COUNT / 10) {
+                fail("ref="+REFS[r]+": expected char refs to be inlined as CHARACTERS, but got "
+                        +entityRefs+" ENTITY_REFERENCE event(s) out of "+ENTITY_COUNT+" refs");
             }
             sr.close();
         }
@@ -185,6 +193,39 @@ public class TestCharRefAsEntsSplit292 extends BaseStreamTest
                 assertTokenType(START_ELEMENT, sr.next());
                 assertEquals(desc, exp, sr.getAttributeValue(0));
                 sr.close();
+            }
+        }
+    }
+
+    // Deterministic coverage of the getText(Writer) sink (readAndWriteText /
+    // readAndWriteCoalesced), for BOTH coalescing and non-coalescing readers --
+    // the cursor sweep above never exercises the Writer path. A leading text char
+    // keeps the body a single CHARACTERS event (content stays < min-text-segment),
+    // and the pad sweep makes the trailing ref straddle the buffer at every
+    // alignment.
+    @Test
+    public void testGetTextWriterSplitSweep() throws Exception {
+        final int bufLen = 11;
+        final boolean[] coalescingModes = { false, true };
+        for (boolean coalescing : coalescingModes) {
+            for (int pad = 0; pad <= 2 * bufLen + 8; ++pad) {
+                StringBuilder p = new StringBuilder("z"); // leading text -> CHARACTERS, not ENTITY_REFERENCE
+                for (int i = 0; i < pad; ++i) {
+                    p.append('x');
+                }
+                for (int r = 0; r < REFS.length; ++r) {
+                    String exp = p + REPLACEMENTS[r];
+                    String desc = "coalescing="+coalescing+",pad="+pad+",ref="+REFS[r];
+
+                    XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(
+                            factory(coalescing, false, bufLen), "<root>"+p+REFS[r]+"</root>");
+                    assertTokenType(START_ELEMENT, sr.next());
+                    assertTokenType(CHARACTERS, sr.next());
+                    StringWriter w = new StringWriter();
+                    sr.getText(w, false);
+                    assertEquals(desc, exp, w.toString());
+                    sr.close();
+                }
             }
         }
     }

--- a/src/test/java/wstxtest/stream/TestCharRefAsEntsSplit292.java
+++ b/src/test/java/wstxtest/stream/TestCharRefAsEntsSplit292.java
@@ -13,26 +13,44 @@ import com.ctc.wstx.api.WstxInputProperties;
  * Test for <a href="https://github.com/FasterXML/woodstox/issues/292">#292</a>:
  * with {@code doTreatCharRefsAsEnts} enabled, character references (and pre-defined
  * entities) that straddle the internal input buffer boundary used to be silently
- * dropped, corrupting the text content.
+ * dropped, corrupting both text content and attribute values.
  */
 public class TestCharRefAsEntsSplit292 extends BaseStreamTest
 {
-    // Build text long enough (and with a small input buffer) to guarantee that
-    // some `&quot;` references end up split across buffer boundaries.
+    // Enough references (against a tiny input buffer) to guarantee that some end
+    // up split across buffer boundaries:
     private final static int ENTITY_COUNT = 1000;
 
-    private static String buildXml() {
+    // Reference forms to exercise: pre-defined entity, decimal char ref, hex char
+    // ref, and a supplementary (surrogate-pair) char ref -- the last one takes a
+    // distinct 2-char replacement path.
+    private final static String[] REFS = {
+        "&quot;", "&#34;", "&#x22;", "&#128512;"
+    };
+    private final static String[] REPLACEMENTS = {
+        "\"", "\"", "\"", "😀" // U+1F600
+    };
+
+    private static String buildText(String ref) {
         StringBuilder sb = new StringBuilder("<root>");
         for (int i = 0; i < ENTITY_COUNT; i++) {
-            sb.append(i).append("&quot;");
+            sb.append(i).append(ref);
         }
         return sb.append("</root>").toString();
     }
 
-    private static String expectedText() {
+    private static String buildAttr(String ref) {
+        StringBuilder sb = new StringBuilder("<root a=\"");
+        for (int i = 0; i < ENTITY_COUNT; i++) {
+            sb.append(i).append(ref);
+        }
+        return sb.append("\"/>").toString();
+    }
+
+    private static String expected(String replacement) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < ENTITY_COUNT; i++) {
-            sb.append(i).append('"');
+            sb.append(i).append(replacement);
         }
         return sb.toString();
     }
@@ -43,7 +61,7 @@ public class TestCharRefAsEntsSplit292 extends BaseStreamTest
         setReplaceEntities(f, true);
         setValidating(f, false);
         f.setProperty(WstxInputProperties.P_TREAT_CHAR_REFS_AS_ENTS, Boolean.TRUE);
-        // Tiny buffer to force splitting of `&quot;` across reads:
+        // Tiny buffer to force splitting of references across reads:
         f.setProperty(WstxInputProperties.P_INPUT_BUFFER_LENGTH, Integer.valueOf(32));
         return f;
     }
@@ -51,40 +69,59 @@ public class TestCharRefAsEntsSplit292 extends BaseStreamTest
     // getText() path, coalescing (single CHARACTERS event)
     @Test
     public void testNoCorruptionCoalescingGetText() throws Exception {
-        XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(true), buildXml());
-        assertTokenType(START_ELEMENT, sr.next());
-        assertTokenType(CHARACTERS, sr.next());
-        assertEquals(expectedText(), sr.getText());
-        assertTokenType(END_ELEMENT, sr.next());
-        sr.close();
+        for (int r = 0; r < REFS.length; ++r) {
+            XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(true), buildText(REFS[r]));
+            assertTokenType(START_ELEMENT, sr.next());
+            assertTokenType(CHARACTERS, sr.next());
+            assertEquals("ref="+REFS[r], expected(REPLACEMENTS[r]), sr.getText());
+            assertTokenType(END_ELEMENT, sr.next());
+            sr.close();
+        }
     }
 
-    // getText() path, non-coalescing (segments accumulated)
+    // getText() path, non-coalescing (segments + entity events accumulated)
     @Test
     public void testNoCorruptionNonCoalescingGetText() throws Exception {
-        XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(false), buildXml());
-        assertTokenType(START_ELEMENT, sr.next());
-        StringBuilder actual = new StringBuilder();
-        int t;
-        while ((t = sr.next()) != END_ELEMENT) {
-            if (t == CHARACTERS || t == ENTITY_REFERENCE) {
-                actual.append(sr.getText());
+        for (int r = 0; r < REFS.length; ++r) {
+            XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(false), buildText(REFS[r]));
+            assertTokenType(START_ELEMENT, sr.next());
+            StringBuilder actual = new StringBuilder();
+            int t;
+            while ((t = sr.next()) != END_ELEMENT) {
+                if (t == CHARACTERS || t == ENTITY_REFERENCE) {
+                    actual.append(sr.getText());
+                }
             }
+            assertEquals("ref="+REFS[r], expected(REPLACEMENTS[r]), actual.toString());
+            sr.close();
         }
-        assertEquals(expectedText(), actual.toString());
-        sr.close();
     }
 
     // getText(Writer) path -> readAndWriteText / readAndWriteCoalesced
     @Test
     public void testNoCorruptionGetTextWriter() throws Exception {
-        XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(true), buildXml());
-        assertTokenType(START_ELEMENT, sr.next());
-        assertTokenType(CHARACTERS, sr.next());
-        StringWriter w = new StringWriter();
-        sr.getText(w, false);
-        assertEquals(expectedText(), w.toString());
-        assertTokenType(END_ELEMENT, sr.next());
-        sr.close();
+        for (int r = 0; r < REFS.length; ++r) {
+            XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(true), buildText(REFS[r]));
+            assertTokenType(START_ELEMENT, sr.next());
+            assertTokenType(CHARACTERS, sr.next());
+            StringWriter w = new StringWriter();
+            sr.getText(w, false);
+            assertEquals("ref="+REFS[r], expected(REPLACEMENTS[r]), w.toString());
+            assertTokenType(END_ELEMENT, sr.next());
+            sr.close();
+        }
+    }
+
+    // parseAttrValue() path
+    @Test
+    public void testNoCorruptionAttributeValue() throws Exception {
+        for (int r = 0; r < REFS.length; ++r) {
+            XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(false), buildAttr(REFS[r]));
+            assertTokenType(START_ELEMENT, sr.next());
+            assertEquals(1, sr.getAttributeCount());
+            assertEquals("ref="+REFS[r], expected(REPLACEMENTS[r]), sr.getAttributeValue(0));
+            assertTokenType(END_ELEMENT, sr.next());
+            sr.close();
+        }
     }
 }

--- a/src/test/java/wstxtest/stream/TestCharRefAsEntsSplit292.java
+++ b/src/test/java/wstxtest/stream/TestCharRefAsEntsSplit292.java
@@ -56,13 +56,18 @@ public class TestCharRefAsEntsSplit292 extends BaseStreamTest
     }
 
     private XMLInputFactory factory(boolean coalescing) throws Exception {
+        // Tiny buffer to force splitting of references across reads:
+        return factory(coalescing, false, 32);
+    }
+
+    private XMLInputFactory factory(boolean coalescing, boolean supportDTD, int bufLen) throws Exception {
         XMLInputFactory f = getInputFactory();
         setCoalescing(f, coalescing);
         setReplaceEntities(f, true);
         setValidating(f, false);
+        setSupportDTD(f, supportDTD);
         f.setProperty(WstxInputProperties.P_TREAT_CHAR_REFS_AS_ENTS, Boolean.TRUE);
-        // Tiny buffer to force splitting of references across reads:
-        f.setProperty(WstxInputProperties.P_INPUT_BUFFER_LENGTH, Integer.valueOf(32));
+        f.setProperty(WstxInputProperties.P_INPUT_BUFFER_LENGTH, Integer.valueOf(bufLen));
         return f;
     }
 
@@ -79,20 +84,36 @@ public class TestCharRefAsEntsSplit292 extends BaseStreamTest
         }
     }
 
-    // getText() path, non-coalescing (segments + entity events accumulated)
+    // getText() path, non-coalescing (multiple CHARACTERS segments).
+    // Also asserts the token contract: with the default (high) min-text-segment,
+    // mid-content char refs are inlined into CHARACTERS, NOT emitted as separate
+    // ENTITY_REFERENCE events -- so a regression that flips inlining back into
+    // standalone entity events is caught, not masked by concatenation.
     @Test
     public void testNoCorruptionNonCoalescingGetText() throws Exception {
         for (int r = 0; r < REFS.length; ++r) {
             XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(false), buildText(REFS[r]));
             assertTokenType(START_ELEMENT, sr.next());
             StringBuilder actual = new StringBuilder();
+            int chars = 0, entityRefs = 0;
             int t;
             while ((t = sr.next()) != END_ELEMENT) {
-                if (t == CHARACTERS || t == ENTITY_REFERENCE) {
+                if (t == CHARACTERS) {
+                    ++chars;
+                    actual.append(sr.getText());
+                } else if (t == ENTITY_REFERENCE) {
+                    ++entityRefs;
                     actual.append(sr.getText());
                 }
             }
             assertEquals("ref="+REFS[r], expected(REPLACEMENTS[r]), actual.toString());
+            if (chars < 1) {
+                fail("ref="+REFS[r]+": expected at least one CHARACTERS event");
+            }
+            if (entityRefs != 0) {
+                fail("ref="+REFS[r]+": expected char refs to be inlined as CHARACTERS, "
+                        +"but got "+entityRefs+" ENTITY_REFERENCE event(s)");
+            }
             sr.close();
         }
     }
@@ -121,6 +142,84 @@ public class TestCharRefAsEntsSplit292 extends BaseStreamTest
             assertEquals(1, sr.getAttributeCount());
             assertEquals("ref="+REFS[r], expected(REPLACEMENTS[r]), sr.getAttributeValue(0));
             assertTokenType(END_ELEMENT, sr.next());
+            sr.close();
+        }
+    }
+
+    // Deterministic coverage: rather than relying on volume to probabilistically
+    // straddle a boundary, sweep the leading-pad length so the reference's start
+    // offset covers every alignment relative to the (small) input buffer. This
+    // guarantees the split path is exercised regardless of future buffer-refill
+    // alignment changes -- in both element content and attribute values.
+    @Test
+    public void testSplitBoundarySweep() throws Exception {
+        final int bufLen = 11;
+        for (int pad = 0; pad <= 2 * bufLen + 8; ++pad) {
+            StringBuilder p = new StringBuilder();
+            for (int i = 0; i < pad; ++i) {
+                p.append('x');
+            }
+            for (int r = 0; r < REFS.length; ++r) {
+                String body = p + REFS[r];
+                String exp = p + REPLACEMENTS[r];
+                String desc = "pad="+pad+",ref="+REFS[r];
+
+                // element content: accumulate across CHARACTERS/ENTITY_REFERENCE,
+                // since a ref at the very start of content is a standalone event
+                XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(
+                        factory(false, false, bufLen), "<root>"+body+"</root>");
+                assertTokenType(START_ELEMENT, sr.next());
+                StringBuilder actual = new StringBuilder();
+                int t;
+                while ((t = sr.next()) != END_ELEMENT) {
+                    if (t == CHARACTERS || t == ENTITY_REFERENCE) {
+                        actual.append(sr.getText());
+                    }
+                }
+                assertEquals(desc, exp, actual.toString());
+                sr.close();
+
+                // attribute value
+                sr = (XMLStreamReader2) constructStreamReader(
+                        factory(false, false, bufLen), "<root a=\""+body+"\"/>");
+                assertTokenType(START_ELEMENT, sr.next());
+                assertEquals(desc, exp, sr.getAttributeValue(0));
+                sr.close();
+            }
+        }
+    }
+
+    // Nested input source interop: a general-entity reference (`&ge;`) creates a
+    // new input source whose expansion itself contains char refs. This exercises
+    // the `mInput` discriminator in takeInlineCharRefReplacement(): the general
+    // entity pushes a source (mInput changes -> must NOT be inlined as a char ref),
+    // while the `&quot;` refs within the expansion are inlined while the active
+    // source is the entity's, not the root document's. Covers content + attribute.
+    @Test
+    public void testNestedEntityCharRefs() throws Exception {
+        // Expansion with several char refs embedded among longer runs of text:
+        final String geRaw = "aaaaaaaaaaaaaaaaaaaa&quot;bbbb&quot;cccccccccccccccccccc&quot;dddd";
+        final String geExpanded = "aaaaaaaaaaaaaaaaaaaa\"bbbb\"cccccccccccccccccccc\"dddd";
+        final String dtd = "<!DOCTYPE root [<!ENTITY ge \"" + geRaw + "\">]>";
+        final String xml = dtd + "<root a=\"X&ge;Y\">P&ge;Q</root>";
+
+        for (int bufLen : new int[] { 16, 24, 32, 64 }) {
+            XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(
+                    factory(true, true, bufLen), xml);
+            int t;
+            while ((t = sr.next()) != START_ELEMENT) {
+                ; // skip DTD (and any prolog) event(s)
+            }
+            String desc = "bufLen=" + bufLen;
+            assertEquals(desc, "X" + geExpanded + "Y", sr.getAttributeValue(0));
+
+            StringBuilder content = new StringBuilder();
+            while ((t = sr.next()) != END_ELEMENT) {
+                if (t == CHARACTERS || t == ENTITY_REFERENCE) {
+                    content.append(sr.getText());
+                }
+            }
+            assertEquals(desc, "P" + geExpanded + "Q", content.toString());
             sr.close();
         }
     }

--- a/src/test/java/wstxtest/stream/TestCharRefAsEntsSplit292.java
+++ b/src/test/java/wstxtest/stream/TestCharRefAsEntsSplit292.java
@@ -31,46 +31,6 @@ public class TestCharRefAsEntsSplit292 extends BaseStreamTest
         "\"", "\"", "\"", "😀" // U+1F600
     };
 
-    private static String buildText(String ref) {
-        StringBuilder sb = new StringBuilder("<root>");
-        for (int i = 0; i < ENTITY_COUNT; i++) {
-            sb.append(i).append(ref);
-        }
-        return sb.append("</root>").toString();
-    }
-
-    private static String buildAttr(String ref) {
-        StringBuilder sb = new StringBuilder("<root a=\"");
-        for (int i = 0; i < ENTITY_COUNT; i++) {
-            sb.append(i).append(ref);
-        }
-        return sb.append("\"/>").toString();
-    }
-
-    private static String expected(String replacement) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < ENTITY_COUNT; i++) {
-            sb.append(i).append(replacement);
-        }
-        return sb.toString();
-    }
-
-    private XMLInputFactory factory(boolean coalescing) throws Exception {
-        // Tiny buffer to force splitting of references across reads:
-        return factory(coalescing, false, 32);
-    }
-
-    private XMLInputFactory factory(boolean coalescing, boolean supportDTD, int bufLen) throws Exception {
-        XMLInputFactory f = getInputFactory();
-        setCoalescing(f, coalescing);
-        setReplaceEntities(f, true);
-        setValidating(f, false);
-        setSupportDTD(f, supportDTD);
-        f.setProperty(WstxInputProperties.P_TREAT_CHAR_REFS_AS_ENTS, Boolean.TRUE);
-        f.setProperty(WstxInputProperties.P_INPUT_BUFFER_LENGTH, Integer.valueOf(bufLen));
-        return f;
-    }
-
     // getText() path, coalescing (single CHARACTERS event)
     @Test
     public void testNoCorruptionCoalescingGetText() throws Exception {
@@ -263,5 +223,51 @@ public class TestCharRefAsEntsSplit292 extends BaseStreamTest
             assertEquals(desc, "P" + geExpanded + "Q", content.toString());
             sr.close();
         }
+    }
+
+    /*
+    ///////////////////////////////////////////////////////////////////////
+    // Helper methods
+    ///////////////////////////////////////////////////////////////////////
+     */
+
+    private static String buildText(String ref) {
+        StringBuilder sb = new StringBuilder("<root>");
+        for (int i = 0; i < ENTITY_COUNT; i++) {
+            sb.append(i).append(ref);
+        }
+        return sb.append("</root>").toString();
+    }
+
+    private static String buildAttr(String ref) {
+        StringBuilder sb = new StringBuilder("<root a=\"");
+        for (int i = 0; i < ENTITY_COUNT; i++) {
+            sb.append(i).append(ref);
+        }
+        return sb.append("\"/>").toString();
+    }
+
+    private static String expected(String replacement) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < ENTITY_COUNT; i++) {
+            sb.append(i).append(replacement);
+        }
+        return sb.toString();
+    }
+
+    private XMLInputFactory factory(boolean coalescing) throws Exception {
+        // Tiny buffer to force splitting of references across reads:
+        return factory(coalescing, false, 32);
+    }
+
+    private XMLInputFactory factory(boolean coalescing, boolean supportDTD, int bufLen) throws Exception {
+        XMLInputFactory f = getInputFactory();
+        setCoalescing(f, coalescing);
+        setReplaceEntities(f, true);
+        setValidating(f, false);
+        setSupportDTD(f, supportDTD);
+        f.setProperty(WstxInputProperties.P_TREAT_CHAR_REFS_AS_ENTS, Boolean.TRUE);
+        f.setProperty(WstxInputProperties.P_INPUT_BUFFER_LENGTH, Integer.valueOf(bufLen));
+        return f;
     }
 }

--- a/src/test/java/wstxtest/stream/TestCharRefAsEntsSplit292.java
+++ b/src/test/java/wstxtest/stream/TestCharRefAsEntsSplit292.java
@@ -1,0 +1,90 @@
+package wstxtest.stream;
+
+import java.io.StringWriter;
+
+import javax.xml.stream.XMLInputFactory;
+
+import org.junit.jupiter.api.Test;
+import org.codehaus.stax2.XMLStreamReader2;
+
+import com.ctc.wstx.api.WstxInputProperties;
+
+/**
+ * Test for <a href="https://github.com/FasterXML/woodstox/issues/292">#292</a>:
+ * with {@code doTreatCharRefsAsEnts} enabled, character references (and pre-defined
+ * entities) that straddle the internal input buffer boundary used to be silently
+ * dropped, corrupting the text content.
+ */
+public class TestCharRefAsEntsSplit292 extends BaseStreamTest
+{
+    // Build text long enough (and with a small input buffer) to guarantee that
+    // some `&quot;` references end up split across buffer boundaries.
+    private final static int ENTITY_COUNT = 1000;
+
+    private static String buildXml() {
+        StringBuilder sb = new StringBuilder("<root>");
+        for (int i = 0; i < ENTITY_COUNT; i++) {
+            sb.append(i).append("&quot;");
+        }
+        return sb.append("</root>").toString();
+    }
+
+    private static String expectedText() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < ENTITY_COUNT; i++) {
+            sb.append(i).append('"');
+        }
+        return sb.toString();
+    }
+
+    private XMLInputFactory factory(boolean coalescing) throws Exception {
+        XMLInputFactory f = getInputFactory();
+        setCoalescing(f, coalescing);
+        setReplaceEntities(f, true);
+        setValidating(f, false);
+        f.setProperty(WstxInputProperties.P_TREAT_CHAR_REFS_AS_ENTS, Boolean.TRUE);
+        // Tiny buffer to force splitting of `&quot;` across reads:
+        f.setProperty(WstxInputProperties.P_INPUT_BUFFER_LENGTH, Integer.valueOf(32));
+        return f;
+    }
+
+    // getText() path, coalescing (single CHARACTERS event)
+    @Test
+    public void testNoCorruptionCoalescingGetText() throws Exception {
+        XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(true), buildXml());
+        assertTokenType(START_ELEMENT, sr.next());
+        assertTokenType(CHARACTERS, sr.next());
+        assertEquals(expectedText(), sr.getText());
+        assertTokenType(END_ELEMENT, sr.next());
+        sr.close();
+    }
+
+    // getText() path, non-coalescing (segments accumulated)
+    @Test
+    public void testNoCorruptionNonCoalescingGetText() throws Exception {
+        XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(false), buildXml());
+        assertTokenType(START_ELEMENT, sr.next());
+        StringBuilder actual = new StringBuilder();
+        int t;
+        while ((t = sr.next()) != END_ELEMENT) {
+            if (t == CHARACTERS || t == ENTITY_REFERENCE) {
+                actual.append(sr.getText());
+            }
+        }
+        assertEquals(expectedText(), actual.toString());
+        sr.close();
+    }
+
+    // getText(Writer) path -> readAndWriteText / readAndWriteCoalesced
+    @Test
+    public void testNoCorruptionGetTextWriter() throws Exception {
+        XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(true), buildXml());
+        assertTokenType(START_ELEMENT, sr.next());
+        assertTokenType(CHARACTERS, sr.next());
+        StringWriter w = new StringWriter();
+        sr.getText(w, false);
+        assertEquals(expectedText(), w.toString());
+        assertTokenType(END_ELEMENT, sr.next());
+        sr.close();
+    }
+}


### PR DESCRIPTION
Fixes #292.
