### PR TITLE
NMTOKEN default value validation skipping first character

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -192,3 +192,8 @@ Skrethel (@Skrethel)
   with `doTreatCharRefsAsEnts` enabled when a character reference is split
   across the internal input buffer boundary
  (7.2.1)
+
+Javeed Khan (@jmestwa-coder)
+
+* Fixed #297: NMTOKEN default value validation skipping first character
+ (7.2.1)

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -6,6 +6,10 @@ Project: woodstox
 
 7.2.1 (not yet released)
 
+#290: Regression in 7.2.0: `writeRaw()` no longer closing an open start
+  element (from #95) breaks emitting whitespace after start/end tags;
+  reverted #95 so `writeRaw()` again closes an open start element
+ (reported by Konrad W)
 #291: Reject overlong UTF-8 sequences in `UTF8Reader`
  (contributed by @aizu-m)
 #292: Text corruption (in element content and attribute values) with
@@ -14,10 +18,8 @@ Project: woodstox
  (reported by @Skrethel)
 #293: Reject out-of-range code points in `UTF32Reader`
  (contributed by @aizu-m)
-#290: Regression in 7.2.0: `writeRaw()` no longer closing an open start
-  element (from #95) breaks emitting whitespace after start/end tags;
-  reverted #95 so `writeRaw()` again closes an open start element
- (reported by Konrad W)
+#297: NMTOKEN default value validation skips first character
+ (fix by @jmestwa-coder)
 
 7.2.0 (19-May-2026)
 

--- a/src/main/java/com/ctc/wstx/io/WstxInputData.java
+++ b/src/main/java/com/ctc/wstx/io/WstxInputData.java
@@ -325,7 +325,7 @@ public class WstxInputData
     public final static int findIllegalNmtokenChar(String nmtoken, boolean nsAware, boolean xml11)
     {
         int len = nmtoken.length();
-        // No special handling for the first char, just the loop: unlike a Name,
+        // No special handling for the first char: unlike a Name,
         // an Nmtoken has no distinct start-char rule, so EVERY character
         // (including the first, index 0) must be a valid NameChar.
         for (int i = 0; i < len; ++i) {

--- a/src/main/java/com/ctc/wstx/io/WstxInputData.java
+++ b/src/main/java/com/ctc/wstx/io/WstxInputData.java
@@ -325,8 +325,10 @@ public class WstxInputData
     public final static int findIllegalNmtokenChar(String nmtoken, boolean nsAware, boolean xml11)
     {
         int len = nmtoken.length();
-        // No special handling for the first char, just the loop
-        for (int i = 1; i < len; ++i) {
+        // No special handling for the first char, just the loop: unlike a Name,
+        // an Nmtoken has no distinct start-char rule, so EVERY character
+        // (including the first, index 0) must be a valid NameChar.
+        for (int i = 0; i < len; ++i) {
             char c = nmtoken.charAt(i);
             if (c <= 0x7A) { // 'z' or earlier
                 if (c >= 0x61) { // 'a' - 'z' are ok

--- a/src/test/java/org/codehaus/stax/test/vstream/TestNmTokenAttrRead.java
+++ b/src/test/java/org/codehaus/stax/test/vstream/TestNmTokenAttrRead.java
@@ -42,7 +42,22 @@ public class TestNmTokenAttrRead
     public void testInvalidNmTokenAttrDecl()
         throws XMLStreamException
     {
-        // ??? Are there any such cases?
+        // A default value whose FIRST character is not a valid NameChar must be
+        // rejected: an Nmtoken is (NameChar)+, with no start-char exception.
+        String XML = "<!DOCTYPE elem [\n"
+            +"<!ELEMENT elem EMPTY>\n"
+            +"<!ATTLIST elem name NMTOKEN '?foo'>\n"
+            +"]>\n<elem />";
+        streamThroughFailing(getValidatingReader(XML),
+                             "invalid NMTOKEN default with illegal first char ('?')");
+
+        // Same for NMTOKENS: first token's leading char illegal
+        XML = "<!DOCTYPE elem [\n"
+            +"<!ELEMENT elem EMPTY>\n"
+            +"<!ATTLIST elem names NMTOKENS '/foo bar'>\n"
+            +"]>\n<elem />";
+        streamThroughFailing(getValidatingReader(XML),
+                             "invalid NMTOKENS default with illegal first char ('/')");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fix an off-by-one error in `findIllegalNmtokenChar()` that caused the first character of NMTOKEN/NMTOKENS default values to be skipped during validation.

## Changes

* Start NMTOKEN validation from index `0` instead of `1`
* Ensure every character in an NMTOKEN is validated as a valid `NameChar`
* Add regression tests covering invalid leading characters in:

  * `NMTOKEN` default values
  * `NMTOKENS` default values

## Impact

* Rejects invalid DTD default values that were previously accepted when the first character was illegal
* Aligns validation behavior with XML NMTOKEN grammar requirements
* Preserves existing behavior for all valid documents

## Testing

* Added regression tests for invalid leading characters (`?foo`, `/foo`)
* Verified tests fail before the fix and pass after the fix
* Full test suite passes successfully