### PR TITLE
NMTOKENS default value validation for single-character tokens

### DIFF
--- a/src/main/java/com/ctc/wstx/dtd/DTDNmTokensAttr.java
+++ b/src/main/java/com/ctc/wstx/dtd/DTDNmTokensAttr.java
@@ -165,14 +165,18 @@ public final class DTDNmTokensAttr
                 c = defValue.charAt(start);
             }
 
+            // Then need to find the end of the token: scan from the char
+            // right after the (known non-space) start char. Note: must check
+            // index `start+1` itself, and must not let `i` run past `len`
+            // (the earlier do/while form skipped start+1 and could overshoot
+            // `len`, throwing StringIndexOutOfBoundsException on the substring
+            // below for single-char tokens). Mirrors DTDAttribute.validateDefaultNames.
             int i = start+1;
-
-            do {
-                if (++i >= len) {
+            for (; i < len; ++i) {
+                if (WstxInputData.isSpaceChar(defValue.charAt(i))) {
                     break;
                 }
-                c = defValue.charAt(i);
-            } while (!WstxInputData.isSpaceChar(c));
+            }
             ++count;
             String token = defValue.substring(start, i);
             int illegalIx = WstxInputData.findIllegalNmtokenChar(token, mCfgNsAware, mCfgXml11);

--- a/src/test/java/org/codehaus/stax/test/vstream/TestNmTokenAttrRead.java
+++ b/src/test/java/org/codehaus/stax/test/vstream/TestNmTokenAttrRead.java
@@ -79,6 +79,52 @@ public class TestNmTokenAttrRead
     }
 
     /**
+     * Unit test for a declared NMTOKENS default value whose tokens are a
+     * single character long. The token-scanning loop in the NMTOKENS default
+     * validator used to skip the char right after a token start and could let
+     * its index run past the value length, throwing a raw
+     * StringIndexOutOfBoundsException (e.g. for default "x") instead of
+     * accepting the perfectly valid value -- and falsely rejecting values
+     * like "a b" whose first token is a single char.
+     */
+    @Test
+    public void testNmTokensDefaultWithSingleCharTokens()
+        throws XMLStreamException
+    {
+        // Default with a single-char token (last token single char), plus
+        // extra spaces, to also exercise normalization/tokenization:
+        String XML = "<!DOCTYPE root [\n"
+            +"<!ELEMENT root (child)>\n"
+            +"<!ELEMENT child EMPTY>\n"
+            +"<!ATTLIST child a NMTOKENS 'x  y z'>\n"
+            +"]>\n<root><child/></root>";
+        XMLStreamReader sr = getValidatingReader(XML);
+        assertTokenType(DTD, sr.next());
+        assertTokenType(START_ELEMENT, sr.next()); // root
+        assertTokenType(START_ELEMENT, sr.next()); // child (gets default)
+        assertEquals("child", sr.getLocalName());
+        assertEquals(1, sr.getAttributeCount());
+        assertEquals("a", sr.getAttributeLocalName(0));
+        // Single-char tokens must be preserved and space-normalized:
+        assertEquals("x y z", sr.getAttributeValue(0));
+        sr.close();
+
+        // A single-char-only default must be accepted (used to throw):
+        streamThrough(getValidatingReader("<!DOCTYPE root [\n"
+            +"<!ELEMENT root EMPTY>\n"
+            +"<!ATTLIST root a NMTOKENS 'x'>\n"
+            +"]>\n<root/>"));
+
+        // ...but an invalid token (illegal char, non-first position) is still
+        // rejected cleanly rather than crashing or being accepted:
+        streamThroughFailing(getValidatingReader("<!DOCTYPE root [\n"
+            +"<!ELEMENT root EMPTY>\n"
+            +"<!ATTLIST root a NMTOKENS 'ok bad/tok'>\n"
+            +"]>\n<root/>"),
+            "invalid NMTOKENS default value (illegal char '/')");
+    }
+
+    /**
      * Unit test that verifies that values of attributes of type NMTOKEN and
      * NMTOKENS will get properly normalized.
      */


### PR DESCRIPTION
## Summary

Fix token scanning in `DTDNmTokensAttr.validateDefault()` when validating DTD-declared `NMTOKENS` default values.

The existing tokenization logic could skip the character immediately following a token start and allow the scan index to advance past the end of the value. As a result, valid default values containing single-character tokens could be misparsed, falsely rejected, or trigger a `StringIndexOutOfBoundsException`.

## Changes

* Replace the token-end scanning loop with a bounded scan that checks every character after the token start.
* Prevent the token index from advancing beyond the input length.
* Align the implementation with the token-scanning approach used by related attribute validators.
* Add regression tests covering single-character token defaults and normalization behavior.

## Result

* Valid `NMTOKENS` default values containing single-character tokens are handled correctly.
* Validation no longer throws `StringIndexOutOfBoundsException` for valid inputs.
* Tokenization behavior is consistent with other DTD attribute validators.
* Regression coverage prevents future reintroduction of the issue.