### PR TITLE
Combine surrogate pairs in `BufferingXmlWriter` entity escaping

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -185,6 +185,8 @@ Aizal Khan (@aizu-m)
  (7.2.1)
 * Contributed fix #293: Reject out-of-range code points in `UTF32Reader`
  (7.2.1)
+* Contributed #300: Combine surrogate pairs in `BufferingXmlWriter` entity escaping
+ (7.2.1)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -4,6 +4,11 @@ Project: woodstox
 === Releases ===
 ------------------------------------------------------------------------
 
+7.2.2 (not yet released)
+
+#300: Combine surrogate pairs in `BufferingXmlWriter` entity escaping
+ (contributed by @aizu-m)
+
 7.2.1 (07-Jun-2026)
 
 #290: Regression in 7.2.0: `writeRaw()` no longer closing an open start
@@ -22,8 +27,6 @@ Project: woodstox
  (fix by @jmestwa-coder)
 #299: NMTOKENS default value validation for single-character tokens
  (fix by @jmestwa-coder)
-#300: Combine surrogate pairs in `BufferingXmlWriter` entity escaping
- (contributed by @aizu-m)
 
 7.2.0 (19-May-2026)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,8 @@ Project: woodstox
  (fix by @jmestwa-coder)
 #299: NMTOKENS default value validation for single-character tokens
  (fix by @jmestwa-coder)
+#300: Combine surrogate pairs in `BufferingXmlWriter` entity escaping
+ (contributed by @aizu-m)
 
 7.2.0 (19-May-2026)
 

--- a/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
@@ -148,12 +148,15 @@ public final class BufferingXmlWriter
      * When a supplementary character has to be output as a character entity
      * (encoding can not represent it natively), the two halves of its
      * surrogate pair must be combined into a single code point first. The
-     * first (high) half is held here when a text/attribute segment ends
-     * between the two halves.
+     * first (high) half is held here when a text segment (a
+     * {@code writeCharacters} call) ends between the two halves, so it can be
+     * paired with the low half delivered by the next text segment. Any other
+     * write while a half is held is rejected via {@link #verifyNoPendingSurrogate}.
+     * Attribute values are atomic and never leave a half pending here.
      *
      * @since 7.2.1
      */
-    protected int mSurrogate = 0;
+    private int mSurrogate = 0;
 
     /*
     ////////////////////////////////////////////////
@@ -226,11 +229,8 @@ public final class BufferingXmlWriter
         flush();
         mTextWriter = null;
         mAttrValueWriter = null;
-        if (mSurrogate != 0) {
-            int surr = mSurrogate;
-            mSurrogate = 0;
-            throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(surr)+")");
-        }
+        // A high surrogate held for pairing must not be left dangling at the end
+        verifyNoPendingSurrogate();
 
         // Buffers to free?
         char[] buf = mOutputBuffer;
@@ -264,6 +264,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
 
         // First; is the new request small or not? If yes, needs to be buffered
         if (len < mSmallWriteSize) { // yup
@@ -321,6 +322,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
         final int len = str.length();
 
         // First; is the new request small or not? If yes, needs to be buffered
@@ -343,6 +345,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
 
         // First; is the new request small or not? If yes, needs to be buffered
         if (len < mSmallWriteSize) { // yup
@@ -820,6 +823,7 @@ public final class BufferingXmlWriter
     public void writeStartTagStart(String localName)
         throws IOException, XMLStreamException
     {
+        verifyNoPendingSurrogate();
         if (mCheckNames) {
             verifyNameValidity(localName, mNsAware);
         }
@@ -842,6 +846,7 @@ public final class BufferingXmlWriter
     public void writeStartTagStart(String prefix, String localName)
         throws IOException, XMLStreamException
     {
+        verifyNoPendingSurrogate();
         if (prefix == null || prefix.length() == 0) { // shouldn't happen
             writeStartTagStart(localName);
             return;
@@ -880,6 +885,7 @@ public final class BufferingXmlWriter
     @Override
     public void writeStartTagEmptyEnd() throws IOException
     {
+        verifyNoPendingSurrogate();
         int ptr = mOutputPtr;
         if ((ptr + 3) >= mOutputBufLen) {
             if (mOut == null) {
@@ -900,6 +906,7 @@ public final class BufferingXmlWriter
     @Override
     public void writeEndTag(String localName) throws IOException
     {
+        verifyNoPendingSurrogate();
         int ptr = mOutputPtr;
         int extra = (mOutputBufLen - ptr) - (3 + localName.length());
         if (extra < 0) {
@@ -921,6 +928,7 @@ public final class BufferingXmlWriter
     @Override
     public void writeEndTag(String prefix, String localName) throws IOException
     {
+        verifyNoPendingSurrogate();
         if (prefix == null || prefix.length() == 0) {
             writeEndTag(localName);
             return;
@@ -966,6 +974,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
         if (mCheckNames) {
             verifyNameValidity(localName, mNsAware);
         }
@@ -1003,6 +1012,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
         if (mCheckNames) {
             verifyNameValidity(localName, mNsAware);
         }
@@ -1039,6 +1049,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
         if (mCheckNames) {
             verifyNameValidity(prefix, mNsAware);
             verifyNameValidity(localName, mNsAware);
@@ -1085,6 +1096,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
         if (mCheckNames) {
             verifyNameValidity(prefix, mNsAware);
             verifyNameValidity(localName, mNsAware);
@@ -1128,16 +1140,6 @@ public final class BufferingXmlWriter
         int inPtr = 0;
         final char qchar = mEncQuoteChar;
         int highChar = mEncHighChar;
-
-        // Pending high surrogate from a previous segment?
-        if (mSurrogate != 0) {
-            if (len == 0) { // nothing to pair with yet
-                return;
-            }
-            int first = mSurrogate;
-            mSurrogate = 0;
-            writeAsEntity(calcSurrogate(first, value.charAt(inPtr++)));
-        }
 
         main_loop:
         while (true) { // main_loop
@@ -1184,12 +1186,10 @@ public final class BufferingXmlWriter
             } else {
                 int ch = value.charAt(inPtr-1);
                 if (ch >= SURR1_FIRST && ch <= SURR2_LAST) { // supplementary char half
-                    if (ch > SURR1_LAST) { // lone low surrogate
+                    // An attribute value is atomic, so both halves must be
+                    // present here; a lone or trailing surrogate is invalid.
+                    if (ch > SURR1_LAST || inPtr >= len) {
                         throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(ch)+")");
-                    }
-                    if (inPtr >= len) { // pair split across segments
-                        mSurrogate = ch;
-                        break main_loop;
                     }
                     ch = calcSurrogate(ch, value.charAt(inPtr++));
                 }
@@ -1204,16 +1204,6 @@ public final class BufferingXmlWriter
         len += offset;
         final char qchar = mEncQuoteChar;
         int highChar = mEncHighChar;
-
-        // Pending high surrogate from a previous segment?
-        if (mSurrogate != 0) {
-            if (offset >= len) { // nothing to pair with yet
-                return;
-            }
-            int first = mSurrogate;
-            mSurrogate = 0;
-            writeAsEntity(calcSurrogate(first, value[offset++]));
-        }
 
         main_loop:
         while (true) { // main_loop
@@ -1260,12 +1250,10 @@ public final class BufferingXmlWriter
             } else {
                 int ch = value[offset-1];
                 if (ch >= SURR1_FIRST && ch <= SURR2_LAST) { // supplementary char half
-                    if (ch > SURR1_LAST) { // lone low surrogate
+                    // An attribute value is atomic, so both halves must be
+                    // present here; a lone or trailing surrogate is invalid.
+                    if (ch > SURR1_LAST || offset >= len) {
                         throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(ch)+")");
-                    }
-                    if (offset >= len) { // pair split across segments
-                        mSurrogate = ch;
-                        break main_loop;
                     }
                     ch = calcSurrogate(ch, value[offset++]);
                 }
@@ -1287,6 +1275,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
 
         int free = mOutputBufLen - mOutputPtr;
         if (enc.bufferNeedsFlush(free)) {
@@ -1310,6 +1299,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
         int free = mOutputBufLen - mOutputPtr;
         if (enc.bufferNeedsFlush(free)) {
             flush();
@@ -1334,6 +1324,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
         if (mCheckNames) {
             verifyNameValidity(localName, mNsAware);
         }
@@ -1375,6 +1366,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
         if (mCheckNames) {
             verifyNameValidity(prefix, mNsAware);
             verifyNameValidity(localName, mNsAware);
@@ -1426,6 +1418,7 @@ public final class BufferingXmlWriter
         if (mOut == null) {
             return;
         }
+        verifyNoPendingSurrogate();
         if (prefix == null) {
             prefix = "";
         }
@@ -1531,6 +1524,7 @@ public final class BufferingXmlWriter
     private final void fastWriteRaw(char c)
         throws IOException
     {
+        verifyNoPendingSurrogate();
         if (mOutputPtr >= mOutputBufLen) {
             if (mOut == null) {
                 return;
@@ -1543,6 +1537,7 @@ public final class BufferingXmlWriter
     private final void fastWriteRaw(char c1, char c2)
         throws IOException
     {
+        verifyNoPendingSurrogate();
         if ((mOutputPtr + 1) >= mOutputBufLen) {
             if (mOut == null) {
                 return;
@@ -1556,6 +1551,7 @@ public final class BufferingXmlWriter
     private final void fastWriteRaw(String str)
         throws IOException
     {
+        verifyNoPendingSurrogate();
         int len = str.length();
         int ptr = mOutputPtr;
         if ((ptr + len) >= mOutputBufLen) {
@@ -1841,6 +1837,22 @@ public final class BufferingXmlWriter
                     +Integer.toHexString(second)+")");
         }
         return 0x10000 + ((first - SURR1_FIRST) << 10) + (second - SURR2_FIRST);
+    }
+
+    /**
+     * Verifies that no high surrogate is being held for pairing before content
+     * other than continuing character data is emitted. A held surrogate at such
+     * a point can never be completed, so it is rejected (mirrors the guarding
+     * done by the byte-backed {@code EncodingXmlWriter} at its output choke
+     * points). Resets the held value so a caught failure does not keep throwing.
+     */
+    private void verifyNoPendingSurrogate() throws IOException
+    {
+        if (mSurrogate != 0) {
+            int surr = mSurrogate;
+            mSurrogate = 0;
+            throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(surr)+")");
+        }
     }
 
     protected final void writeAsEntity(int c)

--- a/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
@@ -154,7 +154,7 @@ public final class BufferingXmlWriter
      * write while a half is held is rejected via {@link #verifyNoPendingSurrogate}.
      * Attribute values are atomic and never leave a half pending here.
      *
-     * @since 7.2.1
+     * @since 7.2.2
      */
     private int mSurrogate = 0;
 
@@ -170,8 +170,7 @@ public final class BufferingXmlWriter
      *    (optional) access to the underlying stream
      */
     public BufferingXmlWriter(Writer out, WriterConfig cfg, String enc,
-                              boolean autoclose,
-                              OutputStream outs, int bitsize)
+            boolean autoclose, OutputStream outs, int bitsize)
         throws IOException
     {
         super(cfg, enc, autoclose);
@@ -563,18 +562,12 @@ public final class BufferingXmlWriter
             if (ent != null) {
                 writeRaw(ent);
             } else {
-                int ch = text.charAt(inPtr-1);
-                if (ch >= SURR1_FIRST && ch <= SURR2_LAST) { // supplementary char half
-                    if (ch > SURR1_LAST) { // lone low surrogate
-                        throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(ch)+")");
-                    }
-                    if (inPtr >= len) { // pair split across segments
-                        mSurrogate = ch;
-                        break main_loop;
-                    }
-                    ch = calcSurrogate(ch, text.charAt(inPtr++));
+                int next = (inPtr < len) ? text.charAt(inPtr) : -1;
+                int adv = writeAsEntityCombined(text.charAt(inPtr-1), next, false);
+                if (adv < 0) { // high half held to pair with the next segment
+                    break main_loop;
                 }
-                writeAsEntity(ch);
+                inPtr += adv;
             }
         }
     }
@@ -660,17 +653,12 @@ public final class BufferingXmlWriter
                 writeRaw(ent);
                 ent = null;
             } else if (offset < len) {
-                if (c >= SURR1_FIRST && c <= SURR2_LAST) { // supplementary char half
-                    if (c > SURR1_LAST) { // lone low surrogate
-                        throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(c)+")");
-                    }
-                    if (offset+1 >= len) { // pair split across segments
-                        mSurrogate = c;
-                        break;
-                    }
-                    c = calcSurrogate(c, cbuf[++offset]);
+                int next = (offset+1 < len) ? cbuf[offset+1] : -1;
+                int adv = writeAsEntityCombined(c, next, false);
+                if (adv < 0) { // high half held to pair with the next segment
+                    break;
                 }
-                writeAsEntity(c);
+                offset += adv;
             }
         } while (++offset < len);
     }
@@ -1184,16 +1172,8 @@ public final class BufferingXmlWriter
             if (ent != null) {
                 writeRaw(ent);
             } else {
-                int ch = value.charAt(inPtr-1);
-                if (ch >= SURR1_FIRST && ch <= SURR2_LAST) { // supplementary char half
-                    // An attribute value is atomic, so both halves must be
-                    // present here; a lone or trailing surrogate is invalid.
-                    if (ch > SURR1_LAST || inPtr >= len) {
-                        throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(ch)+")");
-                    }
-                    ch = calcSurrogate(ch, value.charAt(inPtr++));
-                }
-                writeAsEntity(ch);
+                int next = (inPtr < len) ? value.charAt(inPtr) : -1;
+                inPtr += writeAsEntityCombined(value.charAt(inPtr-1), next, true);
             }
         }
     }
@@ -1248,16 +1228,8 @@ public final class BufferingXmlWriter
             if (ent != null) {
                 writeRaw(ent);
             } else {
-                int ch = value[offset-1];
-                if (ch >= SURR1_FIRST && ch <= SURR2_LAST) { // supplementary char half
-                    // An attribute value is atomic, so both halves must be
-                    // present here; a lone or trailing surrogate is invalid.
-                    if (ch > SURR1_LAST || offset >= len) {
-                        throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(ch)+")");
-                    }
-                    ch = calcSurrogate(ch, value[offset++]);
-                }
-                writeAsEntity(ch);
+                int next = (offset < len) ? value[offset] : -1;
+                offset += writeAsEntityCombined(value[offset-1], next, true);
             }
         }
     }
@@ -1822,6 +1794,44 @@ public final class BufferingXmlWriter
     }
 
     /**
+     * Outputs a single character of text or attribute content as a character
+     * entity, first combining the two halves of a supplementary character into
+     * the single code point they represent (needed when the target encoding can
+     * not represent it natively). A non-surrogate character is output as-is.
+     *<p>
+     * When {@code ch} is the high half of a pair but its low half is not yet
+     * available ({@code next < 0}), behavior depends on {@code atomic}: an
+     * attribute value is indivisible, so the dangling half is rejected;
+     * character content holds it in {@link #mSurrogate} to pair with the next
+     * {@code writeCharacters} call, returning -1 so the caller can stop. A lone
+     * low surrogate is always rejected.
+     *
+     * @param ch character to output (possibly a high surrogate)
+     * @param next following character, or -1 if none is available yet
+     * @param atomic true for attribute values (reject a split pair), false for
+     *    character content (hold the high half for the next call)
+     * @return 1 if {@code next} was consumed to complete a pair, 0 if a single
+     *    character was written, or -1 if a high half was held for a later call
+     */
+    private int writeAsEntityCombined(int ch, int next, boolean atomic)
+        throws IOException
+    {
+        if (ch >= SURR1_FIRST && ch <= SURR2_LAST) { // supplementary char half
+            if (ch > SURR1_LAST || next < 0) { // lone low half, or high half lacking its low half
+                if (atomic || ch > SURR1_LAST) {
+                    throwUnpairedSurrogate(ch);
+                }
+                mSurrogate = ch; // hold high half to pair with the next segment
+                return -1;
+            }
+            writeAsEntity(calcSurrogate(ch, next));
+            return 1;
+        }
+        writeAsEntity(ch);
+        return 0;
+    }
+
+    /**
      * Combines a high/low surrogate pair into the supplementary code point
      * it represents, so it can be output as a single character entity when
      * the target encoding can not represent it natively. Throws for an
@@ -1839,6 +1849,11 @@ public final class BufferingXmlWriter
         return 0x10000 + ((first - SURR1_FIRST) << 10) + (second - SURR2_FIRST);
     }
 
+    private void throwUnpairedSurrogate(int code) throws IOException
+    {
+        throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(code)+")");
+    }
+
     /**
      * Verifies that no high surrogate is being held for pairing before content
      * other than continuing character data is emitted. A held surrogate at such
@@ -1851,7 +1866,7 @@ public final class BufferingXmlWriter
         if (mSurrogate != 0) {
             int surr = mSurrogate;
             mSurrogate = 0;
-            throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(surr)+")");
+            throwUnpairedSurrogate(surr);
         }
     }
 

--- a/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
@@ -150,8 +150,10 @@ public final class BufferingXmlWriter
      * surrogate pair must be combined into a single code point first. The
      * first (high) half is held here when a text/attribute segment ends
      * between the two halves.
+     *
+     * @since 7.2.1
      */
-    private int mSurrogate = 0;
+    protected int mSurrogate = 0;
 
     /*
     ////////////////////////////////////////////////

--- a/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
@@ -1810,8 +1810,11 @@ public final class BufferingXmlWriter
      * @param next following character, or -1 if none is available yet
      * @param atomic true for attribute values (reject a split pair), false for
      *    character content (hold the high half for the next call)
+     *
      * @return 1 if {@code next} was consumed to complete a pair, 0 if a single
      *    character was written, or -1 if a high half was held for a later call
+     *
+     * @since 7.2.2
      */
     private int writeAsEntityCombined(int ch, int next, boolean atomic)
         throws IOException
@@ -1836,6 +1839,8 @@ public final class BufferingXmlWriter
      * it represents, so it can be output as a single character entity when
      * the target encoding can not represent it natively. Throws for an
      * unpaired or otherwise invalid surrogate.
+     *
+     * @since 7.2.2
      */
     private int calcSurrogate(int first, int second)
         throws IOException
@@ -1849,6 +1854,7 @@ public final class BufferingXmlWriter
         return 0x10000 + ((first - SURR1_FIRST) << 10) + (second - SURR2_FIRST);
     }
 
+    // @since 7.2.2
     private void throwUnpairedSurrogate(int code) throws IOException
     {
         throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(code)+")");

--- a/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
@@ -144,6 +144,15 @@ public final class BufferingXmlWriter
      */
     final String mEncQuoteEntity;
 
+    /**
+     * When a supplementary character has to be output as a character entity
+     * (encoding can not represent it natively), the two halves of its
+     * surrogate pair must be combined into a single code point first. The
+     * first (high) half is held here when a text/attribute segment ends
+     * between the two halves.
+     */
+    private int mSurrogate = 0;
+
     /*
     ////////////////////////////////////////////////
     // Life-cycle
@@ -215,6 +224,11 @@ public final class BufferingXmlWriter
         flush();
         mTextWriter = null;
         mAttrValueWriter = null;
+        if (mSurrogate != 0) {
+            int surr = mSurrogate;
+            mSurrogate = 0;
+            throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(surr)+")");
+        }
 
         // Buffers to free?
         char[] buf = mOutputBuffer;
@@ -477,7 +491,17 @@ public final class BufferingXmlWriter
         final int[] QC = QUOTABLE_TEXT_CHARS;
         final int highChar = mEncHighChar;
         final int MAXQC = Math.min(QC.length, highChar);
-        
+
+        // Pending high surrogate from a previous segment?
+        if (mSurrogate != 0) {
+            if (len == 0) { // nothing to pair with yet
+                return;
+            }
+            int first = mSurrogate;
+            mSurrogate = 0;
+            writeAsEntity(calcSurrogate(first, text.charAt(inPtr++)));
+        }
+
         main_loop:
         while (true) {
             String ent = null;
@@ -534,11 +558,22 @@ public final class BufferingXmlWriter
             if (ent != null) {
                 writeRaw(ent);
             } else {
-                writeAsEntity(text.charAt(inPtr-1));
+                int ch = text.charAt(inPtr-1);
+                if (ch >= SURR1_FIRST && ch <= SURR2_LAST) { // supplementary char half
+                    if (ch > SURR1_LAST) { // lone low surrogate
+                        throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(ch)+")");
+                    }
+                    if (inPtr >= len) { // pair split across segments
+                        mSurrogate = ch;
+                        break main_loop;
+                    }
+                    ch = calcSurrogate(ch, text.charAt(inPtr++));
+                }
+                writeAsEntity(ch);
             }
         }
     }
-    
+
     @Override
     public void writeCharacters(char[] cbuf, int offset, int len) throws IOException
     {
@@ -554,6 +589,15 @@ public final class BufferingXmlWriter
         final int highChar = mEncHighChar;
         final int MAXQC = Math.min(QC.length, highChar);
         len += offset;
+        // Pending high surrogate from a previous segment?
+        if (mSurrogate != 0) {
+            if (offset >= len) { // nothing to pair with yet
+                return;
+            }
+            int first = mSurrogate;
+            mSurrogate = 0;
+            writeAsEntity(calcSurrogate(first, cbuf[offset++]));
+        }
         do {
             int c = 0;
             int start = offset;
@@ -611,10 +655,20 @@ public final class BufferingXmlWriter
                 writeRaw(ent);
                 ent = null;
             } else if (offset < len) {
+                if (c >= SURR1_FIRST && c <= SURR2_LAST) { // supplementary char half
+                    if (c > SURR1_LAST) { // lone low surrogate
+                        throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(c)+")");
+                    }
+                    if (offset+1 >= len) { // pair split across segments
+                        mSurrogate = c;
+                        break;
+                    }
+                    c = calcSurrogate(c, cbuf[++offset]);
+                }
                 writeAsEntity(c);
             }
         } while (++offset < len);
-    }    
+    }
 
     /**
      * Method that will try to output the content as specified. If
@@ -1072,11 +1126,21 @@ public final class BufferingXmlWriter
         int inPtr = 0;
         final char qchar = mEncQuoteChar;
         int highChar = mEncHighChar;
-        
+
+        // Pending high surrogate from a previous segment?
+        if (mSurrogate != 0) {
+            if (len == 0) { // nothing to pair with yet
+                return;
+            }
+            int first = mSurrogate;
+            mSurrogate = 0;
+            writeAsEntity(calcSurrogate(first, value.charAt(inPtr++)));
+        }
+
         main_loop:
         while (true) { // main_loop
             String ent = null;
-            
+
             inner_loop:
             while (true) {
                 if (inPtr >= len) {
@@ -1116,7 +1180,18 @@ public final class BufferingXmlWriter
             if (ent != null) {
                 writeRaw(ent);
             } else {
-                writeAsEntity(value.charAt(inPtr-1));
+                int ch = value.charAt(inPtr-1);
+                if (ch >= SURR1_FIRST && ch <= SURR2_LAST) { // supplementary char half
+                    if (ch > SURR1_LAST) { // lone low surrogate
+                        throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(ch)+")");
+                    }
+                    if (inPtr >= len) { // pair split across segments
+                        mSurrogate = ch;
+                        break main_loop;
+                    }
+                    ch = calcSurrogate(ch, value.charAt(inPtr++));
+                }
+                writeAsEntity(ch);
             }
         }
     }
@@ -1127,11 +1202,21 @@ public final class BufferingXmlWriter
         len += offset;
         final char qchar = mEncQuoteChar;
         int highChar = mEncHighChar;
-        
+
+        // Pending high surrogate from a previous segment?
+        if (mSurrogate != 0) {
+            if (offset >= len) { // nothing to pair with yet
+                return;
+            }
+            int first = mSurrogate;
+            mSurrogate = 0;
+            writeAsEntity(calcSurrogate(first, value[offset++]));
+        }
+
         main_loop:
         while (true) { // main_loop
             String ent = null;
-            
+
             inner_loop:
             while (true) {
                 if (offset >= len) {
@@ -1171,7 +1256,18 @@ public final class BufferingXmlWriter
             if (ent != null) {
                 writeRaw(ent);
             } else {
-                writeAsEntity(value[offset-1]);
+                int ch = value[offset-1];
+                if (ch >= SURR1_FIRST && ch <= SURR2_LAST) { // supplementary char half
+                    if (ch > SURR1_LAST) { // lone low surrogate
+                        throw new IOException("Unpaired surrogate character (0x"+Integer.toHexString(ch)+")");
+                    }
+                    if (offset >= len) { // pair split across segments
+                        mSurrogate = ch;
+                        break main_loop;
+                    }
+                    ch = calcSurrogate(ch, value[offset++]);
+                }
+                writeAsEntity(ch);
             }
         }
     }
@@ -1725,6 +1821,24 @@ public final class BufferingXmlWriter
          * even make it just 7, let's see how this works out)
          */
         return 8;
+    }
+
+    /**
+     * Combines a high/low surrogate pair into the supplementary code point
+     * it represents, so it can be output as a single character entity when
+     * the target encoding can not represent it natively. Throws for an
+     * unpaired or otherwise invalid surrogate.
+     */
+    private int calcSurrogate(int first, int second)
+        throws IOException
+    {
+        if (first < SURR1_FIRST || first > SURR1_LAST
+                || second < SURR2_FIRST || second > SURR2_LAST) {
+            throw new IOException("Unpaired surrogate character (first 0x"
+                    +Integer.toHexString(first)+", second 0x"
+                    +Integer.toHexString(second)+")");
+        }
+        return 0x10000 + ((first - SURR1_FIRST) << 10) + (second - SURR2_FIRST);
     }
 
     protected final void writeAsEntity(int c)

--- a/src/main/java/com/ctc/wstx/sw/EncodingXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/EncodingXmlWriter.java
@@ -678,8 +678,6 @@ public abstract class EncodingXmlWriter
         if (nsURI == null) {
             nsURI = "";
         }
-System.err.println("DEBUG: write typed attr/1 '"+localName+"', vld == "+validator);
-
         //validator.validateAttribute(localName, nsURI, (hasPrefix ? prefix: ""), buf, offset, len);
 
         writeAscii(BYTE_SPACE);

--- a/src/test/java/wstxtest/wstream/TestSurrogateEscaping.java
+++ b/src/test/java/wstxtest/wstream/TestSurrogateEscaping.java
@@ -1,0 +1,101 @@
+package wstxtest.wstream;
+
+import java.io.*;
+
+import javax.xml.stream.*;
+
+import org.codehaus.stax2.XMLStreamReader2;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a supplementary character (one requiring a surrogate pair)
+ * is escaped as a single character entity, not two, when the target encoding
+ * can not represent it natively and output goes through a {@code Writer}
+ * (i.e. {@code BufferingXmlWriter}).
+ */
+public class TestSurrogateEscaping
+    extends BaseWriterTest
+{
+    // U+1D11E MUSICAL SYMBOL G CLEF, surrogate pair 0xD834 0xDD1E
+    private final static String ASTRAL = "𝄞";
+
+    @Test
+    public void testSupplementaryCharInTextAndAttr()
+        throws Exception
+    {
+        for (String enc : new String[] { "US-ASCII", "ISO-8859-1" }) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            Writer w = new OutputStreamWriter(bos, enc);
+            XMLStreamWriter sw = getOutputFactory().createXMLStreamWriter(w);
+            sw.writeStartElement("root");
+            sw.writeAttribute("v", "a" + ASTRAL + "b");
+            sw.writeCharacters("c" + ASTRAL + "d");
+            sw.writeEndElement();
+            sw.close();
+            w.flush();
+
+            String xml = bos.toString(enc);
+            // Single, valid entity; never two surrogate-half entities
+            if (xml.indexOf("&#x1d11e;") < 0) {
+                fail("Expected '&#x1d11e;' in output for encoding "+enc+", got: "+xml);
+            }
+            if (xml.indexOf("&#xd834;") >= 0 || xml.indexOf("&#xdd1e;") >= 0) {
+                fail("Output for encoding "+enc+" emitted surrogate-half entities: "+xml);
+            }
+            verifyRoundtrip(xml, "a" + ASTRAL + "b", "c" + ASTRAL + "d");
+        }
+    }
+
+    @Test
+    public void testSupplementaryCharSplitAcrossCalls()
+        throws Exception
+    {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        Writer w = new OutputStreamWriter(bos, "US-ASCII");
+        XMLStreamWriter sw = getOutputFactory().createXMLStreamWriter(w);
+        sw.writeStartElement("root");
+        // Surrogate halves delivered in separate writeCharacters() calls
+        sw.writeCharacters("\uD834");
+        sw.writeCharacters("\uDD1E");
+        sw.writeEndElement();
+        sw.close();
+        w.flush();
+
+        String xml = bos.toString("US-ASCII");
+        if (xml.indexOf("&#x1d11e;") < 0) {
+            fail("Expected combined '&#x1d11e;' for split surrogate, got: "+xml);
+        }
+        verifyRoundtrip(xml, null, ASTRAL);
+    }
+
+    @Test
+    public void testUnpairedSurrogateRejected()
+        throws Exception
+    {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        Writer w = new OutputStreamWriter(bos, "US-ASCII");
+        XMLStreamWriter sw = getOutputFactory().createXMLStreamWriter(w);
+        sw.writeStartElement("root");
+        try {
+            sw.writeCharacters("\uDD1E"); // lone low surrogate
+            sw.writeEndElement();
+            sw.close();
+            fail("Expected failure on unpaired surrogate");
+        } catch (XMLStreamException expected) {
+        }
+    }
+
+    private void verifyRoundtrip(String xml, String expAttr, String expText)
+        throws XMLStreamException
+    {
+        XMLStreamReader2 sr = constructNsStreamReader(xml, true);
+        assertTokenType(START_ELEMENT, sr.next());
+        if (expAttr != null) {
+            assertEquals(expAttr, sr.getAttributeValue(0));
+        }
+        assertTokenType(CHARACTERS, sr.next());
+        assertEquals(expText, getAndVerifyText(sr));
+        assertTokenType(END_ELEMENT, sr.next());
+        sr.close();
+    }
+}

--- a/src/test/java/wstxtest/wstream/TestSurrogateEscaping.java
+++ b/src/test/java/wstxtest/wstream/TestSurrogateEscaping.java
@@ -19,11 +19,15 @@ public class TestSurrogateEscaping
     // U+1D11E MUSICAL SYMBOL G CLEF, surrogate pair 0xD834 0xDD1E
     private final static String ASTRAL = "𝄞";
 
+    // Narrow encodings whose high char sits below the surrogate range, so a
+    // supplementary char must be escaped (and an unpaired half rejected)
+    private final static String[] NARROW_ENCODINGS = { "US-ASCII", "ISO-8859-1" };
+
     @Test
     public void testSupplementaryCharInTextAndAttr()
         throws Exception
     {
-        for (String enc : new String[] { "US-ASCII", "ISO-8859-1" }) {
+        for (String enc : NARROW_ENCODINGS) {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             Writer w = new OutputStreamWriter(bos, enc);
             XMLStreamWriter sw = getOutputFactory().createXMLStreamWriter(w);
@@ -72,16 +76,16 @@ public class TestSurrogateEscaping
     public void testUnpairedSurrogateRejected()
         throws Exception
     {
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        Writer w = new OutputStreamWriter(bos, "US-ASCII");
-        XMLStreamWriter sw = getOutputFactory().createXMLStreamWriter(w);
-        sw.writeStartElement("root");
-        try {
-            sw.writeCharacters("\uDD1E"); // lone low surrogate
-            sw.writeEndElement();
-            sw.close();
-            fail("Expected failure on unpaired surrogate");
-        } catch (XMLStreamException expected) {
+        // lone low surrogate -- invalid regardless of narrow encoding
+        for (String enc : NARROW_ENCODINGS) {
+            XMLStreamWriter sw = startNarrowDoc(enc);
+            try {
+                sw.writeCharacters("\uDD1E");
+                sw.writeEndElement();
+                sw.close();
+                fail("Expected failure on unpaired surrogate ("+enc+")");
+            } catch (XMLStreamException expected) {
+            }
         }
     }
 
@@ -96,16 +100,18 @@ public class TestSurrogateEscaping
     public void testPendingSurrogateDoesNotLeakIntoAttribute()
         throws Exception
     {
-        XMLStreamWriter sw = startAsciiDoc();
-        try {
-            sw.writeCharacters("a\uD834"); // trailing high surrogate held
-            sw.writeStartElement("child");
-            sw.writeAttribute("k", "\uDD1Ez"); // low half of an unrelated value
-            sw.writeEndElement();
-            sw.writeEndElement();
-            sw.close();
-            fail("Expected failure: pending surrogate leaked into following attribute");
-        } catch (XMLStreamException expected) {
+        for (String enc : NARROW_ENCODINGS) {
+            XMLStreamWriter sw = startNarrowDoc(enc);
+            try {
+                sw.writeCharacters("a\uD834"); // trailing high surrogate held
+                sw.writeStartElement("child");
+                sw.writeAttribute("k", "\uDD1Ez"); // low half of an unrelated value
+                sw.writeEndElement();
+                sw.writeEndElement();
+                sw.close();
+                fail("Expected failure: pending surrogate leaked into following attribute ("+enc+")");
+            } catch (XMLStreamException expected) {
+            }
         }
     }
 
@@ -117,13 +123,15 @@ public class TestSurrogateEscaping
     public void testPendingSurrogateRejectedAtEndElement()
         throws Exception
     {
-        XMLStreamWriter sw = startAsciiDoc();
-        try {
-            sw.writeCharacters("a\uD834");
-            sw.writeEndElement();
-            sw.close();
-            fail("Expected failure: pending surrogate at end of element");
-        } catch (XMLStreamException expected) {
+        for (String enc : NARROW_ENCODINGS) {
+            XMLStreamWriter sw = startNarrowDoc(enc);
+            try {
+                sw.writeCharacters("a\uD834");
+                sw.writeEndElement();
+                sw.close();
+                fail("Expected failure: pending surrogate at end of element ("+enc+")");
+            } catch (XMLStreamException expected) {
+            }
         }
     }
 
@@ -135,20 +143,22 @@ public class TestSurrogateEscaping
     public void testTrailingHighSurrogateInAttributeRejected()
         throws Exception
     {
-        XMLStreamWriter sw = startAsciiDoc();
-        try {
-            sw.writeAttribute("k", "x\uD834");
-            sw.writeEndElement();
-            sw.close();
-            fail("Expected failure: trailing high surrogate in attribute value");
-        } catch (XMLStreamException expected) {
+        for (String enc : NARROW_ENCODINGS) {
+            XMLStreamWriter sw = startNarrowDoc(enc);
+            try {
+                sw.writeAttribute("k", "x\uD834");
+                sw.writeEndElement();
+                sw.close();
+                fail("Expected failure: trailing high surrogate in attribute value ("+enc+")");
+            } catch (XMLStreamException expected) {
+            }
         }
     }
 
-    private XMLStreamWriter startAsciiDoc()
+    private XMLStreamWriter startNarrowDoc(String enc)
         throws Exception
     {
-        Writer w = new OutputStreamWriter(new ByteArrayOutputStream(), "US-ASCII");
+        Writer w = new OutputStreamWriter(new ByteArrayOutputStream(), enc);
         XMLStreamWriter sw = getOutputFactory().createXMLStreamWriter(w);
         sw.writeStartElement("root");
         return sw;

--- a/src/test/java/wstxtest/wstream/TestSurrogateEscaping.java
+++ b/src/test/java/wstxtest/wstream/TestSurrogateEscaping.java
@@ -85,6 +85,75 @@ public class TestSurrogateEscaping
         }
     }
 
+    /**
+     * A high surrogate held for pairing at the end of a text segment must not
+     * leak into a following, unrelated write. Previously the held half was
+     * silently combined with the next escaped content (e.g. a different
+     * element's attribute), moving the character and corrupting output; it now
+     * must be rejected, matching the byte-backed writers.
+     */
+    @Test
+    public void testPendingSurrogateDoesNotLeakIntoAttribute()
+        throws Exception
+    {
+        XMLStreamWriter sw = startAsciiDoc();
+        try {
+            sw.writeCharacters("a\uD834"); // trailing high surrogate held
+            sw.writeStartElement("child");
+            sw.writeAttribute("k", "\uDD1Ez"); // low half of an unrelated value
+            sw.writeEndElement();
+            sw.writeEndElement();
+            sw.close();
+            fail("Expected failure: pending surrogate leaked into following attribute");
+        } catch (XMLStreamException expected) {
+        }
+    }
+
+    /**
+     * A high surrogate left pending by a text write must be rejected when the
+     * next operation ends the element rather than continuing character data.
+     */
+    @Test
+    public void testPendingSurrogateRejectedAtEndElement()
+        throws Exception
+    {
+        XMLStreamWriter sw = startAsciiDoc();
+        try {
+            sw.writeCharacters("a\uD834");
+            sw.writeEndElement();
+            sw.close();
+            fail("Expected failure: pending surrogate at end of element");
+        } catch (XMLStreamException expected) {
+        }
+    }
+
+    /**
+     * An attribute value is atomic, so a high surrogate as its final char can
+     * never be completed and must be rejected immediately (not held).
+     */
+    @Test
+    public void testTrailingHighSurrogateInAttributeRejected()
+        throws Exception
+    {
+        XMLStreamWriter sw = startAsciiDoc();
+        try {
+            sw.writeAttribute("k", "x\uD834");
+            sw.writeEndElement();
+            sw.close();
+            fail("Expected failure: trailing high surrogate in attribute value");
+        } catch (XMLStreamException expected) {
+        }
+    }
+
+    private XMLStreamWriter startAsciiDoc()
+        throws Exception
+    {
+        Writer w = new OutputStreamWriter(new ByteArrayOutputStream(), "US-ASCII");
+        XMLStreamWriter sw = getOutputFactory().createXMLStreamWriter(w);
+        sw.writeStartElement("root");
+        return sw;
+    }
+
     private void verifyRoundtrip(String xml, String expAttr, String expText)
         throws XMLStreamException
     {


### PR DESCRIPTION
Writer-backed output to a narrow encoding mangles supplementary characters.

    <root v="x&#xd834;&#xdd1e;y">text&#xd834;&#xdd1e;end</root>

That is U+1D11E written through a US-ASCII OutputStreamWriter. Each half of
the surrogate pair gets escaped on its own, so the document carries two
character references whose code points fall in the surrogate block. Those are
illegal in XML 1.0 4.1, and re-parsing the output throws.

Traced it to BufferingXmlWriter, the writer used when the target is a
java.io.Writer. The text and attribute escaping loops call writeAsEntity once
per char. The byte-backed AsciiXmlWriter/ISOLatin1XmlWriter already join the
pair through calcSurrogate before escaping; this writer was the odd one out.
Only narrow encodings are affected, where mEncHighChar sits below the
surrogate range. For UTF-8 the surrogates pass straight through to the
underlying writer and stay correct.

Fix joins the two halves into the real code point before writeAsEntity at all
four sites (text/attribute, String/char[]), holds a high half that lands on a
segment boundary so it can pair with the next call, and rejects an unpaired
surrogate instead of writing a broken entity. Output becomes &#x1d11e; and
round-trips.
