### PR TITLE
Reject U+00D7 and U+00F7 in `is11NameChar()`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -185,6 +185,8 @@ Aizal Khan (@aizu-m)
  (7.2.1)
 * Contributed fix #293: Reject out-of-range code points in `UTF32Reader`
  (7.2.1)
+* Contributed #301: Reject U+00D7 and U+00F7 in `is11NameChar()`
+ (7.2.2)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,8 @@ Project: woodstox
  (fix by @jmestwa-coder)
 #299: NMTOKENS default value validation for single-character tokens
  (fix by @jmestwa-coder)
+#301: Reject U+00D7 and U+00F7 in `is11NameChar()`
+ (contributed by @aizu-m)
 
 7.2.0 (19-May-2026)
 

--- a/src/main/java/com/ctc/wstx/util/XmlChars.java
+++ b/src/main/java/com/ctc/wstx/util/XmlChars.java
@@ -454,7 +454,7 @@ public final class XmlChars
     {
         // Others are checked block-by-block:
         if (c <= 0x2FEF) {
-            if (c < 0x2000) { // 8-bit ctrl chars, 0xD7/0xF7 and 0x37E to filter out
+            if (c < 0x2000) { // below 0xC0 (except 0xB7), plus 0xD7/0xF7/0x37E, to filter out
                 return (c >= 0x00C0 && c != 0xD7 && c != 0xF7 && c != 0x37E) || (c == 0xB7);
             }
             if (c >= 0x2C00) {

--- a/src/main/java/com/ctc/wstx/util/XmlChars.java
+++ b/src/main/java/com/ctc/wstx/util/XmlChars.java
@@ -454,8 +454,8 @@ public final class XmlChars
     {
         // Others are checked block-by-block:
         if (c <= 0x2FEF) {
-            if (c < 0x2000) { // only 8-bit ctrl chars and 0x37E to filter out
-                return (c >= 0x00C0 && c != 0x37E) || (c == 0xB7);
+            if (c < 0x2000) { // 8-bit ctrl chars, 0xD7/0xF7 and 0x37E to filter out
+                return (c >= 0x00C0 && c != 0xD7 && c != 0xF7 && c != 0x37E) || (c == 0xB7);
             }
             if (c >= 0x2C00) {
                 // 0x100 - 0x1FFF, 0x2C00 - 0x2FEF are ok

--- a/src/test/java/wstxtest/util/TestXmlChars.java
+++ b/src/test/java/wstxtest/util/TestXmlChars.java
@@ -72,4 +72,28 @@ public class TestXmlChars
         assertFalse(WstxInputData.isNameStartChar(':', true, true));
         assertFalse(WstxInputData.isNameStartChar((char) 0x3000, true, true));
     }
+
+    // U+00D7 (MULTIPLICATION SIGN) and U+00F7 (DIVISION SIGN) sit in the gaps of
+    // the XML 1.1 NameStartChar ranges ([#xC0-#xD6], [#xD8-#xF6], [#xF8-#x2FF])
+    // and are not added back by NameChar, so neither is a legal name char.
+    @Test
+    public void testXml11MultiplicationDivisionNotNameChars()
+    {
+        // already rejected as name-start chars...
+        assertFalse(WstxInputData.isNameStartChar((char) 0xD7, true, true));
+        assertFalse(WstxInputData.isNameStartChar((char) 0xF7, true, true));
+        // ...and must be rejected as later name chars too
+        assertFalse(WstxInputData.isNameChar((char) 0xD7, true, true));
+        assertFalse(WstxInputData.isNameChar((char) 0xF7, true, true));
+
+        // neighbours stay legal
+        assertTrue(WstxInputData.isNameChar((char) 0xD6, true, true));
+        assertTrue(WstxInputData.isNameChar((char) 0xD8, true, true));
+        assertTrue(WstxInputData.isNameChar((char) 0xF6, true, true));
+        assertTrue(WstxInputData.isNameChar((char) 0xF8, true, true));
+
+        // middle dot is a name char but not a name-start char
+        assertTrue(WstxInputData.isNameChar((char) 0xB7, true, true));
+        assertFalse(WstxInputData.isNameStartChar((char) 0xB7, true, true));
+    }
 }


### PR DESCRIPTION
Spotted while cross-checking the XML 1.1 name classifiers against the grammar. is11NameStartChar rejects U+00D7 and U+00F7, but is11NameChar accepts them:

    isNameChar((char) 0xD7, true, true) => true   (expected false)
    isNameChar((char) 0xF7, true, true) => true   (expected false)

× (U+00D7) and ÷ (U+00F7) fall in the holes of the NameStartChar ranges ([#xC0-#xD6], [#xD8-#xF6], [#xF8-#x2FF]), and the NameChar production does not add them back, so neither is a legal XML 1.1 name char. The 0xC0–0x1FFF branch only filtered 0x37E and let those two through. The start-char method right next to it already had the guard, this one did not.

Consequence: in 1.1 mode names like a×b parse as well-formed, and on the writer side findIllegalNameChar emits them without complaint. is10NameChar is table-driven and already leaves both unset.

Added the two exclusions so is11NameChar matches is11NameStartChar. New TestXmlChars case covers ×/÷ plus the 0xD6/0xD8/0xF6/0xF8 neighbours and the 0xB7 middle-dot.