### PR TITLE
Check for `]]>` in content split across input buffer boundary

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -187,6 +187,8 @@ Aizal Khan (@aizu-m)
  (7.2.1)
 * Contributed #301: Reject U+00D7 and U+00F7 in `is11NameChar()`
  (7.2.2)
+* Contributed #303: Check for `]]>` in content split across input buffer boundary
+ (7.2.2)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -8,6 +8,8 @@ Project: woodstox
 
 #301: Reject U+00D7 and U+00F7 in `is11NameChar()`
  (contributed by @aizu-m)
+#303: Check for `]]>` in content split across input buffer boundary
+ (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)
 

--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -4799,7 +4799,10 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
         final int end = mInputEnd;
         int ptr = scanPtr;
         int brackets = prevBrackets;
-        while (brackets < 2 && ptr < end && buf[ptr] == ']') {
+        // Skip ALL leading ']' (not just up to two): a run like "]]]>" straddling
+        // the boundary still ends in "]]>" and must be rejected. Stopping at two
+        // would leave ptr on a ']' and miss the following '>'.
+        while (ptr < end && buf[ptr] == ']') {
             ++brackets;
             ++ptr;
         }

--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -4964,13 +4964,7 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                     // not quite sure why this is needed... but it is:
                     inputLen = mInputEnd;
                 } else if (c == '>') {
-                    // Let's see if we got ']]>'?
-                    /* 21-Apr-2005, TSa: But we can NOT check the output buffer
-                     *  as it contains _expanded_ stuff... only input side.
-                     *  For now, 98% accuracy has to do, as we may not be able
-                     *  to access previous buffer's contents. But at least we
-                     *  won't produce false positives from entity expansion
-                     */
+                    // Let's see if we got ']]>'? First: fully in-buffer case
                     if (inputPtr > 2) { // can we do it here?
                         // Since mInputPtr has been advanced, -1 refers to '>'
                         if (inputBuffer[inputPtr-3] == ']'
@@ -4984,12 +4978,11 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                             mPendingException = throwWfcException(ErrorConsts.ERR_BRACKET_IN_TEXT, deferErrors);
                             break;
                         }
-                    } else {
-                        // '>' is among the first chars of the buffer: a ']]'
-                        // ending the previous buffer is handled at load time by
-                        // checkBracketBoundary(), so nothing to do here.
-                        ;
                     }
+                    /* else { */
+                    // 16-Jun-2026, tatu: [woodstox#303] Split-buffer case
+                    //   handled by checking for ']' or ']]' ending the previous buffer
+                    //   at load time by checkBracketBoundary(), so nothing to do here.
                 }
             }
             // Ok, let's add char to output:
@@ -5449,9 +5442,8 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                     }
                     start = mInputPtr;
                 } else if (c == '>') { // did we get ']]>'?
-                    /* 21-Apr-2005, TSa: But we can NOT check the output buffer
-                     *  (see comments in readTextSecondary() for details)
-                     */
+                    // 21-Apr-2005, TSa: But we can NOT check the output buffer
+                    //  (see comments in readTextSecondary() for details)
                     if (mInputPtr >= 3) { // can we do it here?
                         if (mInputBuffer[mInputPtr-3] == ']'
                             && mInputBuffer[mInputPtr-2] == ']') {
@@ -5462,18 +5454,15 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                             }
                             throwParseError(ErrorConsts.ERR_BRACKET_IN_TEXT);
                         }
-                    } else {
-                        // Past-boundary ']]' is handled at load time by
-                        // checkBracketBoundary(), so nothing to do here.
-                        ;
-                    }
+                    } // else {
+                    // 16-Jun-2026, tatu: [woodstox#303] Split-buffer case
+                    //   handled by checking for ']' or ']]' ending the previous buffer
+                    //   at load time by checkBracketBoundary(), so nothing to do here.
                 }
             }
         } // while (true)
 
-        /* Need to push back '<' or '&', whichever caused us to
-         * get out...
-         */
+        // Need to push back '<' or '&', whichever caused us to get out...
         --mInputPtr;
 
         // Anything left to flush?

--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -4782,8 +4782,35 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
     }
 
     /**
+     * Called right after a new input buffer has been loaded while reading
+     * textual content, when the buffer that was just replaced ended with one
+     * or two {@code ']'} characters. Those trailing brackets are no longer
+     * accessible to the in-buffer look-back that normally detects {@code "]]>"}
+     * in content, so without this check a {@code "]]>"} split across the buffer
+     * boundary would be accepted (it is not allowed in content, XML 1.0/1.1 #2.4).
      *
-     * @param deferErrors Flag to enable storing an exception to a 
+     * @param prevBrackets Number of trailing {@code ']'} (1 or 2) the previous buffer ended with
+     * @param scanPtr Index of the first character of the freshly loaded content
+     */
+    private void checkBracketBoundary(int prevBrackets, int scanPtr)
+        throws XMLStreamException
+    {
+        final char[] buf = mInputBuffer;
+        final int end = mInputEnd;
+        int ptr = scanPtr;
+        int brackets = prevBrackets;
+        while (brackets < 2 && ptr < end && buf[ptr] == ']') {
+            ++brackets;
+            ++ptr;
+        }
+        if (brackets >= 2 && ptr < end && buf[ptr] == '>') {
+            throwWfcException(ErrorConsts.ERR_BRACKET_IN_TEXT, false);
+        }
+    }
+
+    /**
+     *
+     * @param deferErrors Flag to enable storing an exception to a
      *   variable, instead of immediately throwing it. If true, will
      *   just store the exception; if false, will not store, just throw.
      *
@@ -4811,12 +4838,25 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                  *   then throw an exception: no need to do that yet.
                  */
                 mInputPtr = inputPtr;
+                // Number of ']' the buffer about to be discarded ends with; needed
+                // so a "]]>" split across the boundary is still caught below.
+                int prevBrackets = 0;
+                if (inputLen > 0 && inputBuffer[inputLen-1] == ']') {
+                    prevBrackets = (inputLen > 1 && inputBuffer[inputLen-2] == ']') ? 2 : 1;
+                }
+                WstxInputSource srcBefore = mInput;
                 if (!loadMore()) {
                     break;
                 }
                 inputPtr = mInputPtr;
                 inputBuffer = mInputBuffer;
                 inputLen = mInputEnd;
+                // Only a plain refill of the same source can split a literal "]]>";
+                // ']]' pulled in from an entity is legitimately quoted, so skip the
+                // check when loadMore() crossed an input-source (entity) boundary.
+                if (prevBrackets > 0 && mInput == srcBefore) {
+                    checkBracketBoundary(prevBrackets, inputPtr);
+                }
             }
             char c = inputBuffer[inputPtr++];
 
@@ -4942,10 +4982,9 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                             break;
                         }
                     } else {
-                        /* 21-Apr-2005, TSa: No good way to verify it,
-                         *   at this point. Should come back and think of how
-                         *   to properly handle this (rare) possibility.
-                         */
+                        // '>' is among the first chars of the buffer: a ']]'
+                        // ending the previous buffer is handled at load time by
+                        // checkBracketBoundary(), so nothing to do here.
                         ;
                     }
                 }
@@ -5282,8 +5321,20 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                     w.write(mInputBuffer, start, len);
                     count += len;
                 }
+                // Number of ']' the buffer about to be discarded ends with; needed
+                // so a "]]>" split across the boundary is still caught below.
+                int prevBrackets = 0;
+                if (mInputEnd > 0 && mInputBuffer[mInputEnd-1] == ']') {
+                    prevBrackets = (mInputEnd > 1 && mInputBuffer[mInputEnd-2] == ']') ? 2 : 1;
+                }
+                WstxInputSource srcBefore = mInput;
                 c = getNextChar(SUFFIX_IN_TEXT);
                 start = mInputPtr-1; // needs to be prior to char we got
+                // ']]' pulled in from an entity is legitimately quoted: only flag a
+                // split "]]>" when the buffer was refilled from the same source.
+                if (prevBrackets > 0 && mInput == srcBefore) {
+                    checkBracketBoundary(prevBrackets, mInputPtr-1);
+                }
             } else {
                 c = mInputBuffer[mInputPtr++];
             }
@@ -5409,7 +5460,9 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                             throwParseError(ErrorConsts.ERR_BRACKET_IN_TEXT);
                         }
                     } else {
-                        ; // !!! TBI: how to check past boundary?
+                        // Past-boundary ']]' is handled at load time by
+                        // checkBracketBoundary(), so nothing to do here.
+                        ;
                     }
                 }
             }

--- a/src/test/java/wstxtest/stream/TestCDataEndInTextSplit.java
+++ b/src/test/java/wstxtest/stream/TestCDataEndInTextSplit.java
@@ -1,0 +1,171 @@
+package wstxtest.stream;
+
+import java.io.StringWriter;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+
+import org.junit.jupiter.api.Test;
+import org.codehaus.stax2.XMLStreamReader2;
+
+import com.ctc.wstx.api.WstxInputProperties;
+
+/**
+ * Test that the well-formedness check forbidding a literal {@code "]]>"} in
+ * character content (XML 1.0/1.1 #2.4) still fires when the sequence is split
+ * across the internal input-buffer boundary. Previously the look-back used to
+ * spot {@code "]]>"} only inspected the current buffer, so a sequence whose
+ * {@code "]]"} ended one buffer and whose {@code '>'} started the next was
+ * silently accepted.
+ *<p>
+ * The complementary case must keep working: {@code "]]"} produced by a general
+ * entity followed by a literal {@code '>'} is legitimately quoted (the literal
+ * string never appears in the source) and must parse cleanly at every alignment.
+ */
+public class TestCDataEndInTextSplit extends BaseStreamTest
+{
+    // small enough that the pad sweep below straddles the boundary at every offset
+    private final static int BUF_LEN = 11;
+
+    // Illegal literal "]]>" in element content, swept across all buffer alignments
+    @Test
+    public void testSplitBracketEndContent() throws Exception {
+        for (int pad = 0; pad <= 3 * BUF_LEN + 8; ++pad) {
+            String xml = "<root>" + pad(pad) + "]]></root>";
+            assertRejected("content pad="+pad, factory(false, false), xml);
+            assertRejected("content-coalescing pad="+pad, factory(true, false), xml);
+        }
+    }
+
+    // Same, through the getText(Writer) sink (readAndWriteText)
+    @Test
+    public void testSplitBracketEndGetTextWriter() throws Exception {
+        for (int pad = 0; pad <= 3 * BUF_LEN + 8; ++pad) {
+            // leading 'z' keeps content a single CHARACTERS event
+            String xml = "<root>z" + pad(pad) + "]]></root>";
+            XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(true, false), xml);
+            boolean rejected = false;
+            try {
+                assertTokenType(START_ELEMENT, sr.next());
+                sr.next();
+                sr.getText(new StringWriter(), false);
+                while (sr.next() != END_ELEMENT) { }
+            } catch (Exception e) {
+                if (!isBracketError(e)) {
+                    throw e;
+                }
+                rejected = true;
+            }
+            if (!rejected) {
+                fail("getText(Writer) pad="+pad+": expected split ']]>' to be rejected");
+            }
+            sr.close();
+        }
+    }
+
+    // Legal: a general entity expanding to "]]" then a literal '>' is quoted and
+    // must NOT be flagged, regardless of where the boundary falls.
+    @Test
+    public void testEntityQuotedBracketsAllowed() throws Exception {
+        final String dtd = "<!DOCTYPE root [<!ENTITY bb \"]]\">]>";
+        for (int pad = 0; pad <= 3 * BUF_LEN + 8; ++pad) {
+            String p = pad(pad);
+            String xml = dtd + "<root>" + p + "&bb;></root>";
+            XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(false, true), xml);
+            int t;
+            while ((t = sr.next()) != START_ELEMENT) {
+                ; // skip DTD / prolog
+            }
+            StringBuilder actual = new StringBuilder();
+            while ((t = sr.next()) != END_ELEMENT) {
+                if (t == CHARACTERS || t == ENTITY_REFERENCE) {
+                    actual.append(sr.getText());
+                }
+            }
+            assertEquals("pad="+pad, p + "]]>", actual.toString());
+            sr.close();
+        }
+    }
+
+    // Legal: single ']' before '>' (and a trailing "]]" not followed by '>') are
+    // fine, including across the boundary.
+    @Test
+    public void testLegalBracketsAllowed() throws Exception {
+        String[] bodies = { "]>", "]]", "x]]x", "]]]" };
+        for (String body : bodies) {
+            for (int pad = 0; pad <= 3 * BUF_LEN + 8; ++pad) {
+                String content = pad(pad) + body;
+                String xml = "<root>" + content + "</root>";
+                XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(factory(false, false), xml);
+                assertTokenType(START_ELEMENT, sr.next());
+                StringBuilder actual = new StringBuilder();
+                int t;
+                while ((t = sr.next()) != END_ELEMENT) {
+                    if (t == CHARACTERS || t == ENTITY_REFERENCE) {
+                        actual.append(sr.getText());
+                    }
+                }
+                assertEquals("body="+body+",pad="+pad, content, actual.toString());
+                sr.close();
+            }
+        }
+    }
+
+    /*
+    ///////////////////////////////////////////////////////////////////////
+    // Helper methods
+    ///////////////////////////////////////////////////////////////////////
+     */
+
+    private void assertRejected(String desc, XMLInputFactory f, String xml) throws Exception {
+        XMLStreamReader2 sr = (XMLStreamReader2) constructStreamReader(f, xml);
+        try {
+            int t;
+            while ((t = sr.next()) != END_ELEMENT) {
+                if (t == CHARACTERS || t == ENTITY_REFERENCE) {
+                    sr.getText();
+                }
+            }
+            fail(desc + ": expected split ']]>' in content to be rejected");
+        } catch (Exception e) {
+            if (!isBracketError(e)) {
+                throw e;
+            }
+        } finally {
+            sr.close();
+        }
+    }
+
+    // getText() may surface the deferred error lazily (as a RuntimeException), so
+    // accept either form as long as it is the "]]>" well-formedness error.
+    private static boolean isBracketError(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            String msg = t.getMessage();
+            if (msg != null && msg.indexOf("]]>") >= 0) {
+                return true;
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return false;
+    }
+
+    private static String pad(int len) {
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; ++i) {
+            sb.append('x');
+        }
+        return sb.toString();
+    }
+
+    private XMLInputFactory factory(boolean coalescing, boolean supportDTD) throws XMLStreamException {
+        XMLInputFactory f = getInputFactory();
+        setCoalescing(f, coalescing);
+        setReplaceEntities(f, true);
+        setValidating(f, false);
+        setSupportDTD(f, supportDTD);
+        f.setProperty(WstxInputProperties.P_INPUT_BUFFER_LENGTH, Integer.valueOf(BUF_LEN));
+        return f;
+    }
+}

--- a/src/test/java/wstxtest/stream/TestCDataEndInTextSplit.java
+++ b/src/test/java/wstxtest/stream/TestCDataEndInTextSplit.java
@@ -27,13 +27,18 @@ public class TestCDataEndInTextSplit extends BaseStreamTest
     // small enough that the pad sweep below straddles the boundary at every offset
     private final static int BUF_LEN = 11;
 
-    // Illegal literal "]]>" in element content, swept across all buffer alignments
+    // Illegal literal "]]>" in element content, swept across all buffer alignments.
+    // Includes longer bracket runs ("]]]>", "]]]]>") whose trailing "]]>" must be
+    // caught even when two or more brackets end one buffer and "]>" opens the next.
     @Test
     public void testSplitBracketEndContent() throws Exception {
-        for (int pad = 0; pad <= 3 * BUF_LEN + 8; ++pad) {
-            String xml = "<root>" + pad(pad) + "]]></root>";
-            assertRejected("content pad="+pad, factory(false, false), xml);
-            assertRejected("content-coalescing pad="+pad, factory(true, false), xml);
+        String[] tails = { "]]>", "]]]>", "]]]]>", "x]]]>" };
+        for (String tail : tails) {
+            for (int pad = 0; pad <= 3 * BUF_LEN + 8; ++pad) {
+                String xml = "<root>" + pad(pad) + tail + "</root>";
+                assertRejected("content tail="+tail+" pad="+pad, factory(false, false), xml);
+                assertRejected("content-coalescing tail="+tail+" pad="+pad, factory(true, false), xml);
+            }
         }
     }
 


### PR DESCRIPTION
Chasing a stray `]]>` that survived in text content, it only reproduced on some inputs. It comes down to the input buffer boundary. With a small `P_INPUT_BUFFER_LENGTH`:

    <root>xxxxxxxxxxxxxxxxxxxx]]></root>
       split   ]] | >   -> getText() hands back "]]>" in content, no error
       single read      -> "String ']]>' not allowed in textual content"

`readTextSecondary()` and `readAndWriteText()` spot `]]>` by looking back within the current input buffer when a `>` is read. If the `]]` ends one buffer and the `>` opens the next, the look-back cannot see the brackets and the check passes. The 2005 comment already flagged it ("come back and think of how to properly handle this rare possibility").

Added the missing check at the refill: record how many `]` the buffer being dropped ends with, then after `loadMore()` test whether the freshly loaded buffer completes a `]]>`. Gated on the input source staying the same, so `]]` expanded from a general entity ahead of a literal `>` (the quoted `&bb;>` form) is left untouched.

New test sweeps the pad length so the sequence straddles the tiny buffer at every alignment, covering plain content, the `getText(Writer)` sink, the entity-quoted negative case and other legal bracket runs.
