### PR TITLE
Fix non-BMP character entity serialization in `BufferingXmlWriter`

### DIFF
--- a/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/BufferingXmlWriter.java
@@ -534,11 +534,16 @@ public final class BufferingXmlWriter
             if (ent != null) {
                 writeRaw(ent);
             } else {
-                writeAsEntity(text.charAt(inPtr-1));
+                int cp = surrogateAwareCodePoint(text.charAt(inPtr-1),
+                        (inPtr < len) ? text.charAt(inPtr) : -1);
+                writeAsEntity(cp);
+                if (cp > 0xFFFF) { // consumed trailing low surrogate too
+                    ++inPtr;
+                }
             }
         }
     }
-    
+
     @Override
     public void writeCharacters(char[] cbuf, int offset, int len) throws IOException
     {
@@ -611,10 +616,15 @@ public final class BufferingXmlWriter
                 writeRaw(ent);
                 ent = null;
             } else if (offset < len) {
-                writeAsEntity(c);
+                int cp = surrogateAwareCodePoint((char) c,
+                        (offset+1 < len) ? cbuf[offset+1] : -1);
+                writeAsEntity(cp);
+                if (cp > 0xFFFF) { // consumed trailing low surrogate too
+                    ++offset;
+                }
             }
         } while (++offset < len);
-    }    
+    }
 
     /**
      * Method that will try to output the content as specified. If
@@ -1116,7 +1126,12 @@ public final class BufferingXmlWriter
             if (ent != null) {
                 writeRaw(ent);
             } else {
-                writeAsEntity(value.charAt(inPtr-1));
+                int cp = surrogateAwareCodePoint(value.charAt(inPtr-1),
+                        (inPtr < len) ? value.charAt(inPtr) : -1);
+                writeAsEntity(cp);
+                if (cp > 0xFFFF) { // consumed trailing low surrogate too
+                    ++inPtr;
+                }
             }
         }
     }
@@ -1171,7 +1186,12 @@ public final class BufferingXmlWriter
             if (ent != null) {
                 writeRaw(ent);
             } else {
-                writeAsEntity(value[offset-1]);
+                int cp = surrogateAwareCodePoint(value[offset-1],
+                        (offset < len) ? value[offset] : -1);
+                writeAsEntity(cp);
+                if (cp > 0xFFFF) { // consumed trailing low surrogate too
+                    ++offset;
+                }
             }
         }
     }
@@ -1794,5 +1814,47 @@ public final class BufferingXmlWriter
         }
         buf[ptr++] = ';';
         mOutputPtr = ptr;
+    }
+
+    /**
+     * Resolve a character that has to be emitted as a numeric character
+     * reference (because the output encoding can not represent it natively)
+     * into the code point that {@link #writeAsEntity} should output.
+     *<p>
+     * The complication is supplementary characters: in a Java {@code String}
+     * they are stored as a high/low surrogate pair. Emitting each half as its
+     * own reference would produce {@code &#xd83d;&#xde00;} style output, i.e.
+     * references to surrogate code points, which are <b>not</b> legal XML
+     * characters (XML 1.0 [2], 1.1 [2]) and which this very library's reader
+     * rejects. Instead we recombine the pair into the single supplementary
+     * code point so a single, well-formed reference is written. Unpaired or
+     * mis-ordered surrogates are rejected, matching the byte-backed writers
+     * ({@code EncodingXmlWriter#calcSurrogate}).
+     *
+     * @param first the character that needs escaping
+     * @param next the following character if one is available, otherwise -1
+     * @return code point to pass to {@link #writeAsEntity}; the caller must
+     *   skip the following character iff the result is a supplementary code
+     *   point (i.e. greater than {@code 0xFFFF})
+     */
+    private int surrogateAwareCodePoint(char first, int next) throws IOException
+    {
+        if (!Character.isSurrogate(first)) {
+            return first;
+        }
+        if (Character.isHighSurrogate(first)
+                && next >= 0 && Character.isLowSurrogate((char) next)) {
+            return Character.toCodePoint(first, (char) next);
+        }
+        // either a lone low surrogate, or a high surrogate not followed by a
+        // low one: can not be represented as a legal character reference
+        throwUnpairedSurrogate(first);
+        return first; // never reached
+    }
+
+    private void throwUnpairedSurrogate(int code) throws IOException
+    {
+        throw new IOException("Unpaired surrogate character (0x"
+                +Integer.toHexString(code)+") in content to write out");
     }
 }

--- a/src/test/java/org/codehaus/stax/test/wstream/TestNonBmpOutput.java
+++ b/src/test/java/org/codehaus/stax/test/wstream/TestNonBmpOutput.java
@@ -1,0 +1,114 @@
+package org.codehaus.stax.test.wstream;
+
+import java.io.*;
+
+import javax.xml.stream.*;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for [woodstox#xxx]: when a supplementary (non-BMP)
+ * character has to be emitted as a numeric character reference (because the
+ * output encoding can not represent it natively), the {@code Writer}-backed
+ * output path ({@code BufferingXmlWriter}) used to write each half of the
+ * UTF-16 surrogate pair as its own reference, e.g. {@code &#xd83d;&#xde00;}.
+ * Those reference surrogate code points, which are not legal XML characters,
+ * so the result is not well-formed and is rejected on re-parse (including by
+ * Woodstox's own reader). The character must instead be written as a single
+ * reference, here {@code &#x1f600;}.
+ *<p>
+ * The byte-backed writers (US-ASCII / ISO-8859-1) already handled this; the
+ * gap was specific to other (8-bit) encodings, which take the buffering path.
+ */
+public class TestNonBmpOutput
+    extends BaseWriterTest
+{
+    // U+1F600 GRINNING FACE, built from its code point so the source-file
+    // encoding can not corrupt the literal.
+    private final String NON_BMP = new String(Character.toChars(0x1F600));
+
+    // windows-1252 is an ordinary 8-bit encoding that routes through the
+    // buffering (Writer-backed) output path.
+    private final String ENCODING = "windows-1252";
+
+    @Test
+    public void testNonBmpInCharacters() throws Exception
+    {
+        byte[] doc = write(true);
+        String serialized = new String(doc, ENCODING);
+
+        assertTrue("Should emit a single combined character reference, got: " + serialized,
+                serialized.contains("&#x1f600;"));
+        assertFalse("Must not emit lone-surrogate references: " + serialized,
+                serialized.toLowerCase().contains("d83d"));
+
+        // ... and the output must be well-formed and round-trip faithfully:
+        XMLStreamReader sr = getInputFactory().createXMLStreamReader(
+                new ByteArrayInputStream(doc));
+        assertTokenType(START_ELEMENT, sr.nextTag());
+        assertTokenType(CHARACTERS, sr.next());
+        assertEquals(NON_BMP, getAllText(sr));
+        sr.close();
+    }
+
+    @Test
+    public void testNonBmpInAttribute() throws Exception
+    {
+        byte[] doc = write(false);
+        String serialized = new String(doc, ENCODING);
+
+        assertTrue("Should emit a single combined character reference, got: " + serialized,
+                serialized.contains("&#x1f600;"));
+        assertFalse("Must not emit lone-surrogate references: " + serialized,
+                serialized.toLowerCase().contains("d83d"));
+
+        XMLStreamReader sr = getInputFactory().createXMLStreamReader(
+                new ByteArrayInputStream(doc));
+        assertTokenType(START_ELEMENT, sr.nextTag());
+        assertEquals(1, sr.getAttributeCount());
+        assertEquals(NON_BMP, sr.getAttributeValue(0));
+        sr.close();
+    }
+
+    /**
+     * A genuinely unpaired surrogate can not be represented and must be
+     * reported rather than silently emitted as an illegal reference.
+     */
+    @Test
+    public void testUnpairedSurrogateRejected() throws Exception
+    {
+        XMLOutputFactory f = getOutputFactory();
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        XMLStreamWriter w = f.createXMLStreamWriter(bos, ENCODING);
+        w.writeStartElement("root");
+        try {
+            w.writeCharacters("x\uD83Dy"); // high surrogate not followed by a low one
+            w.writeEndElement();
+            w.writeEndDocument();
+            w.close();
+            fail("Expected an exception for an unpaired surrogate, got: "
+                    + new String(bos.toByteArray(), ENCODING));
+        } catch (XMLStreamException expected) {
+            // ok
+        } catch (RuntimeException expected) {
+            // some StAX impls wrap the IOException; ok as long as it is reported
+        }
+    }
+
+    private byte[] write(boolean asText) throws Exception
+    {
+        XMLOutputFactory f = getOutputFactory();
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        XMLStreamWriter w = f.createXMLStreamWriter(bos, ENCODING);
+        w.writeStartDocument(ENCODING, "1.0");
+        w.writeStartElement("root");
+        if (asText) {
+            w.writeCharacters(NON_BMP);
+        } else {
+            w.writeAttribute("attr", NON_BMP);
+        }
+        w.writeEndElement();
+        w.writeEndDocument();
+        w.close();
+        return bos.toByteArray();
+    }
+}


### PR DESCRIPTION
Fix incorrect serialization of supplementary Unicode characters when `BufferingXmlWriter` emits numeric character references.

Previously, when a character outside the Basic Multilingual Plane (BMP) could not be represented directly in the target output encoding, `BufferingXmlWriter` serialized each UTF-16 surrogate half as an independent numeric character reference. This produced output such as:

```xml
&#xd83d;&#xde00;
```

These references target surrogate code points, which are not legal XML characters, resulting in malformed XML output.

## Root Cause

`BufferingXmlWriter` passed UTF-16 code units directly to `writeAsEntity()` when escaping characters that could not be represented in the configured output encoding.

For supplementary characters, Java stores the character as a high/low surrogate pair. Instead of recombining the pair into a single Unicode code point before entity serialization, the writer emitted separate references for each surrogate half.

The byte-oriented writer implementations already perform surrogate validation and recombination, but the buffering writer path did not.

## Changes

* Add surrogate-aware code point handling before numeric entity serialization.
* Recombine valid high/low surrogate pairs into a single Unicode code point.
* Reject unpaired or malformed surrogate sequences instead of emitting invalid XML.
* Apply the fix consistently to:

  * `writeCharacters(String)`
  * `writeCharacters(char[])`
  * attribute value serialization paths

## Tests

Add regression coverage for:

* Supplementary character serialization in text content.
* Supplementary character serialization in attribute values.
* Rejection of unpaired surrogate sequences.

Before this change, the tests fail because the writer emits surrogate code point references. After the fix, all tests pass and the generated XML remains well-formed.