### PR TITLE
Fix XML 1.1 Restricted Character Validation for Reader Inputs

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -210,7 +210,7 @@ Javeed Khan (@jmestwa-coder)
 
 @metsw24-max
 
-* Contributed#305: Fix XML 1.1 Restricted Character Validation for Reader Inputs
+* Contributed #305: Fix XML 1.1 Restricted Character Validation for Reader Inputs
  (7.2.2)
 
 Joe Jensen (@joejensen)

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -221,7 +221,7 @@ Javeed Khan (@jmestwa-coder)
 @metsw24-max
 
 * Contributed #305: Fix XML 1.1 Restricted Character Validation for Reader Inputs
- (7.2.2)
+ (7.3.0)
 
 Joe Jensen (@joejensen)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -8,6 +8,11 @@ Project: woodstox
 
 #301: Reject U+00D7 and U+00F7 in `is11NameChar()`
  (contributed by @aizu-m)
+* Enforce XML 1.1 "restricted characters" (C1 control range U+007F-U+009F,
+  except U+0085 NEL) for `Reader`-based input as well. Previously these were
+  only rejected while decoding bytes (`InputStream` input), so the same document
+  was accepted or rejected depending solely on whether it was supplied as a
+  `Reader` or an `InputStream`; now `ReaderSource` applies the same check.
 
 7.2.1 (07-Jun-2026)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -13,7 +13,7 @@ Project: woodstox
 #303: Check for `]]>` in content split across input buffer boundary
  (contributed by @aizu-m)
 #305: Fix XML 1.1 Restricted Character Validation for Reader Inputs
- (contributed by @ metsw24-max)
+ (contributed by @metsw24-max)
 #306: Escape tab, newline and CR in `TextEscaper.writeEscapedAttrValue()`
  (contributed by @aizu-m)
 #308: Regression in `NonNsStreamWriter` which causes erroneous `WstxOutputException`

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -6,7 +6,8 @@ Project: woodstox
 
 7.3.0 (not yet released)
 
--
+#305: Fix XML 1.1 Restricted Character Validation for Reader Inputs
+ (contributed by @metsw24-max)
 
 7.2.2 (03-Aug-2026)
 
@@ -16,8 +17,6 @@ Project: woodstox
  (contributed by @aizu-m)
 #303: Check for `]]>` in content split across input buffer boundary
  (contributed by @aizu-m)
-#305: Fix XML 1.1 Restricted Character Validation for Reader Inputs
- (contributed by @metsw24-max)
 #306: Escape tab, newline and CR in `TextEscaper.writeEscapedAttrValue()`
  (contributed by @aizu-m)
 #308: Regression in `NonNsStreamWriter` which causes erroneous `WstxOutputException`

--- a/src/main/java/com/ctc/wstx/io/InputSourceFactory.java
+++ b/src/main/java/com/ctc/wstx/io/InputSourceFactory.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import javax.xml.stream.Location;
 
 import com.ctc.wstx.api.ReaderConfig;
+import com.ctc.wstx.cfg.XmlConsts;
 
 /**
  * Factory class that creates instances of {@link WstxInputSource} to allow
@@ -36,6 +37,7 @@ public final class InputSourceFactory
             rs.setInputOffsets(bs.getInputTotal(), bs.getInputRow(),
                                -bs.getInputColumn());
         }
+        rs.setXmlCompliancy(xmlVersion);
         return rs;
     }
 
@@ -58,6 +60,9 @@ public final class InputSourceFactory
         if (bs != null) {
             rs.setInputOffsets(bs.getInputTotal(), bs.getInputRow(),
                                -bs.getInputColumn());
+            if (bs.declaredXml11()) {
+                rs.setXmlCompliancy(XmlConsts.XML_V_11);
+            }
         }
         return rs;
     }

--- a/src/main/java/com/ctc/wstx/io/ReaderSource.java
+++ b/src/main/java/com/ctc/wstx/io/ReaderSource.java
@@ -129,7 +129,7 @@ public class ReaderSource
             return -1;
         }
         if (mCheckXml11Chars) {
-            verifyXml11Chars(mBuffer, 0, count);
+            verifyXml11Chars(mBuffer, 0, count, reader.mCurrInputProcessed);
         }
         reader.mInputBuffer = mBuffer;
         reader.mInputPtr = 0;
@@ -182,7 +182,7 @@ public class ReaderSource
                 return false;
             }
             if (mCheckXml11Chars) {
-                verifyXml11Chars(mBuffer, currAmount, currAmount + actual);
+                verifyXml11Chars(mBuffer, currAmount, currAmount + actual, reader.mCurrInputProcessed);
             }
             currAmount += actual;
             minAmount -= actual;
@@ -201,19 +201,24 @@ public class ReaderSource
      * Mirrors the check performed by {@link UTF8Reader} (and the other
      * {@link BaseReader} subclasses) for {@code InputStream}-based input, so
      * that {@code Reader}-based input is validated identically.
+     *
+     * @param baseProcessed Number of characters processed before
+     *   {@code buf[0]} (i.e. {@code reader.mCurrInputProcessed}); used so the
+     *   reported character position is the absolute document offset rather than
+     *   a buffer-local one.
      */
-    private void verifyXml11Chars(char[] buf, int start, int end)
+    private void verifyXml11Chars(char[] buf, int start, int end, long baseProcessed)
         throws IOException
     {
         for (int i = start; i < end; ++i) {
             char c = buf[i];
             if (c >= 0x7F && c <= 0x9F && c != 0x85) {
-                reportInvalidXml11(c, mInputProcessed + i);
+                reportInvalidXml11(c, baseProcessed + i);
             }
         }
     }
 
-    private void reportInvalidXml11(int value, int charPos)
+    private void reportInvalidXml11(int value, long charPos)
         throws IOException
     {
         // Matches BaseReader.reportInvalidXml11 so behavior is the same whether

--- a/src/main/java/com/ctc/wstx/io/ReaderSource.java
+++ b/src/main/java/com/ctc/wstx/io/ReaderSource.java
@@ -1,11 +1,13 @@
 package com.ctc.wstx.io;
 
+import java.io.CharConversionException;
 import java.io.IOException;
 import java.io.Reader;
 
 import javax.xml.stream.XMLStreamException;
 
 import com.ctc.wstx.api.ReaderConfig;
+import com.ctc.wstx.cfg.XmlConsts;
 import com.ctc.wstx.exc.WstxException;
 
 /**
@@ -31,6 +33,21 @@ public class ReaderSource
     int mInputRow = 1;
     int mInputRowStart = 0;
 
+    /**
+     * Whether characters read from {@link #mReader} need to be checked for
+     * XML 1.1 "restricted characters" (the C1 control range U+007F&ndash;U+009F,
+     * except U+0085 NEL) that are only legal when expressed via character
+     * references.
+     *<p>
+     * This is only enabled when (a) the document is XML 1.1 and (b) the
+     * underlying Reader is an application- (or JDK-) supplied one rather than
+     * one of Woodstox's own decoding Readers ({@link BaseReader}), which already
+     * perform this check while decoding bytes. Without this, the same logical
+     * document is accepted or rejected depending solely on whether it was handed
+     * to the parser as an {@code InputStream} or as a {@code Reader}.
+     */
+    boolean mCheckXml11Chars = false;
+
     public ReaderSource(ReaderConfig cfg, WstxInputSource parent, String fromEntity,
                         String pubId, SystemId sysId,
                         Reader r, boolean realClose)
@@ -53,6 +70,18 @@ public class ReaderSource
         mInputProcessed = proc;
         mInputRow = row;
         mInputRowStart = rowStart;
+    }
+
+    /**
+     * Method called to indicate the XML version this source is being read as.
+     * For XML 1.1 we need to verify the "restricted characters" of the C1
+     * control range unless the underlying Reader already does so while decoding
+     * bytes (i.e. is one of Woodstox's own {@link BaseReader}s).
+     */
+    public void setXmlCompliancy(int xmlVersion)
+    {
+        mCheckXml11Chars = (xmlVersion == XmlConsts.XML_V_11)
+            && !(mReader instanceof BaseReader);
     }
 
     /**
@@ -98,6 +127,9 @@ public class ReaderSource
                 throw new WstxException("Reader (of type "+mReader.getClass().getName()+") returned 0 characters, even when asked to read up to "+mBuffer.length, getLocation());
             }
             return -1;
+        }
+        if (mCheckXml11Chars) {
+            verifyXml11Chars(mBuffer, 0, count);
         }
         reader.mInputBuffer = mBuffer;
         reader.mInputPtr = 0;
@@ -149,11 +181,46 @@ public class ReaderSource
                 reader.mInputEnd = mInputLast = currAmount;
                 return false;
             }
+            if (mCheckXml11Chars) {
+                verifyXml11Chars(mBuffer, currAmount, currAmount + actual);
+            }
             currAmount += actual;
             minAmount -= actual;
         }
         reader.mInputEnd = mInputLast = currAmount;
         return true;
+    }
+
+    /**
+     * Verifies that the given character range does not contain XML 1.1
+     * "restricted characters" from the C1 control range (U+007F&ndash;U+009F,
+     * excluding U+0085 NEL) that are only legal when written as character
+     * references. The C0 control range (below U+0020) is left to the tokenizer,
+     * which already rejects those regardless of input source.
+     *<p>
+     * Mirrors the check performed by {@link UTF8Reader} (and the other
+     * {@link BaseReader} subclasses) for {@code InputStream}-based input, so
+     * that {@code Reader}-based input is validated identically.
+     */
+    private void verifyXml11Chars(char[] buf, int start, int end)
+        throws IOException
+    {
+        for (int i = start; i < end; ++i) {
+            char c = buf[i];
+            if (c >= 0x7F && c <= 0x9F && c != 0x85) {
+                reportInvalidXml11(c, mInputProcessed + i);
+            }
+        }
+    }
+
+    private void reportInvalidXml11(int value, int charPos)
+        throws IOException
+    {
+        // Matches BaseReader.reportInvalidXml11 so behavior is the same whether
+        // the document was supplied as an InputStream or as a Reader.
+        throw new CharConversionException("Invalid character 0x"
+                +Integer.toHexString(value)
+                +", can only be included in xml 1.1 using character entities (at char #"+charPos+")");
     }
 
     @Override

--- a/src/test/java/stax2/stream/TestXml11RestrictedCharsViaReader.java
+++ b/src/test/java/stax2/stream/TestXml11RestrictedCharsViaReader.java
@@ -1,0 +1,137 @@
+package stax2.stream;
+
+import java.io.ByteArrayInputStream;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.codehaus.stax2.XMLInputFactory2;
+import org.junit.jupiter.api.Test;
+
+import stax2.BaseStax2Test;
+
+/**
+ * Tests for [woodstox-core]: XML 1.1 "restricted characters" of the C1 control
+ * range (U+007F&ndash;U+009F, except U+0085 NEL) must be rejected when they
+ * appear literally (i.e. not via character references), regardless of whether
+ * the document is supplied as an {@code InputStream} or as a {@code Reader}.
+ *<p>
+ * Before the fix, the check lived only in Woodstox's own byte-decoding Readers,
+ * so {@code Reader}-based (or exotic-encoding) input silently accepted these
+ * restricted control characters, while the same bytes were rejected when read
+ * from an {@code InputStream}. These tests pin the now-consistent behavior;
+ * they construct the reader from a {@link java.io.StringReader} (the path that
+ * used to bypass the check) and assert rejection.
+ */
+public class TestXml11RestrictedCharsViaReader extends BaseStax2Test
+{
+    private final static String XML11_DECL = "<?xml version=\"1.1\"?>";
+
+    // // // Restricted C1 controls: must be rejected when read via a Reader
+
+    @Test
+    public void testRestrictedC1InContentViaReader() throws Exception
+    {
+        // sample across the restricted range: 0x7F (DEL), 0x84, 0x86, 0x90, 0x9F
+        for (int c : new int[] { 0x7F, 0x84, 0x86, 0x90, 0x9F }) {
+            String doc = XML11_DECL + "<root>A" + ((char) c) + "B</root>";
+            assertRejectedViaReader(doc, c);
+        }
+    }
+
+    @Test
+    public void testRestrictedC1InAttributeViaReader() throws Exception
+    {
+        String doc = XML11_DECL + "<root attr=\"x" + ((char) 0x90) + "y\">z</root>";
+        assertRejectedViaReader(doc, 0x90);
+    }
+
+    @Test
+    public void testRestrictedC1InCDataViaReader() throws Exception
+    {
+        String doc = XML11_DECL + "<root><![CDATA[A" + ((char) 0x93) + "B]]></root>";
+        assertRejectedViaReader(doc, 0x93);
+    }
+
+    @Test
+    public void testRestrictedC1AcrossBufferBoundaryViaReader() throws Exception
+    {
+        // Push the restricted char well past the first buffer fill so that the
+        // readMore() refill path is exercised, not just the initial readInto().
+        StringBuilder sb = new StringBuilder(XML11_DECL).append("<root>");
+        for (int i = 0; i < 50000; ++i) {
+            sb.append('x');
+        }
+        sb.append((char) 0x90).append("</root>");
+        assertRejectedViaReader(sb.toString(), 0x90);
+    }
+
+    // // // Things that must STILL be accepted (no over-rejection)
+
+    @Test
+    public void testAllowedCharsViaReaderXml11() throws Exception
+    {
+        // U+0085 (NEL) and U+00A0 (NBSP) are NOT restricted; plain content too.
+        for (int c : new int[] { 0x09, 0x41, 0x85, 0xA0, 0x100 }) {
+            String doc = XML11_DECL + "<root>A" + ((char) c) + "B</root>";
+            assertAcceptedViaReader(doc);
+        }
+    }
+
+    @Test
+    public void testRestrictedC1AsCharRefAllowedViaReader() throws Exception
+    {
+        // Restricted chars ARE legal when expressed as character references.
+        String doc = XML11_DECL + "<root>A&#x90;B</root>";
+        assertAcceptedViaReader(doc);
+    }
+
+    @Test
+    public void testRestrictedC1AllowedInXml10ViaReader() throws Exception
+    {
+        // In XML 1.0 the C1 range is ordinary content and must not be rejected.
+        String doc = "<?xml version=\"1.0\"?><root>A" + ((char) 0x90) + "B</root>";
+        assertAcceptedViaReader(doc);
+    }
+
+    // // // Cross-check: InputStream path already behaved this way and is unchanged
+
+    @Test
+    public void testRestrictedC1ViaInputStreamStillRejected() throws Exception
+    {
+        String doc = XML11_DECL + "<root>A" + ((char) 0x90) + "B</root>";
+        XMLInputFactory2 f = getInputFactory();
+        XMLStreamReader sr = (XMLStreamReader) f.createXMLStreamReader(
+                new ByteArrayInputStream(doc.getBytes("UTF-8")));
+        try {
+            streamThrough(sr);
+            fail("Expected XML 1.1 restricted char 0x90 to be rejected for InputStream input");
+        } catch (XMLStreamException e) {
+            // expected
+        }
+    }
+
+    // // // Helpers
+
+    private void assertRejectedViaReader(String doc, int expectedChar) throws Exception
+    {
+        XMLInputFactory2 f = getInputFactory();
+        XMLStreamReader sr = constructStreamReader(f, doc);
+        try {
+            streamThrough(sr);
+            fail("Expected XML 1.1 restricted char 0x" + Integer.toHexString(expectedChar)
+                    + " to be rejected when read via a Reader");
+        } catch (XMLStreamException e) {
+            // expected
+        }
+    }
+
+    private void assertAcceptedViaReader(String doc) throws Exception
+    {
+        XMLInputFactory2 f = getInputFactory();
+        XMLStreamReader sr = constructStreamReader(f, doc);
+        // Should consume the whole document without throwing:
+        streamThrough(sr);
+        sr.close();
+    }
+}


### PR DESCRIPTION
Ensure XML 1.1 restricted character validation is applied consistently for documents parsed through both `Reader` and `InputStream` sources.

Prior to this change, validation of XML 1.1 restricted C1 control characters (U+007F–U+009F, excluding U+0085 NEL) occurred only in Woodstox's byte-decoding readers. As a result, XML supplied through a `Reader` could bypass these checks and be accepted even though the same document would be rejected when parsed through an `InputStream`.

This patch extends validation to the `ReaderSource` path, eliminating the inconsistency and ensuring identical well-formedness behavior regardless of input source type.

## Changes

* Add XML 1.1 restricted-character validation to `ReaderSource`.
* Propagate XML compliancy configuration through `InputSourceFactory`.
* Avoid duplicate validation for Woodstox internal `BaseReader` implementations.
* Preserve existing exception behavior for invalid characters.
* Add regression tests covering:

  * Restricted characters in element content.
  * Restricted characters in attributes.
  * Restricted characters in CDATA sections.
  * Buffer refill (`readMore`) boundary handling.
  * Allowed XML 1.1 characters and character references.
  * XML 1.0 compatibility.
  * InputStream parity verification.
* Add release notes entry for the fix.

## Before

* XML 1.1 restricted C1 control characters were rejected for `InputStream` input.
* The same characters could be accepted when the document was supplied via a `Reader`.

## After

* XML 1.1 restricted C1 control characters are rejected consistently for both `Reader` and `InputStream` inputs.
* Validation behavior no longer depends on the input source implementation.

## Testing

* Added `TestXml11RestrictedCharsViaReader`.
* Verified restricted characters are rejected across all affected contexts.
* Verified allowed characters and character references continue to parse successfully.
* Full test suite passes successfully.