### PR TITLE
Escape tab, newline and CR in `TextEscaper.writeEscapedAttrValue()`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -191,6 +191,8 @@ Aizal Khan (@aizu-m)
  (7.2.2)
 * Contributed #303: Check for `]]>` in content split across input buffer boundary
  (7.2.2)
+* Contributed #306: Escape tab, newline and CR in `TextEscaper.writeEscapedAttrValue()`
+ (7.2.2)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -12,6 +12,8 @@ Project: woodstox
  (contributed by @aizu-m)
 #303: Check for `]]>` in content split across input buffer boundary
  (contributed by @aizu-m)
+#306: Escape tab, newline and CR in `TextEscaper.writeEscapedAttrValue()`
+ (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)
 

--- a/src/main/java/com/ctc/wstx/io/TextEscaper.java
+++ b/src/main/java/com/ctc/wstx/io/TextEscaper.java
@@ -23,7 +23,8 @@ public final class TextEscaper
 
             for (; i < len; ++i) {
                 c = value.charAt(i);
-                if (c == '<' || c == '&' || c == '"') {
+                if (c == '<' || c == '&' || c == '"'
+                    || c == '\t' || c == '\n' || c == '\r') {
                     break;
                 }
             }
@@ -38,7 +39,14 @@ public final class TextEscaper
                     w.write("&amp;");
                 } else if (c == '"') {
                     w.write("&quot;");
-
+                } else if (c == '\t') {
+                    // Whitespace chars must be escaped, or attribute-value
+                    // normalization (XML 1.0 #3.3.3) collapses them to spaces
+                    w.write("&#x9;");
+                } else if (c == '\n') {
+                    w.write("&#xA;");
+                } else if (c == '\r') {
+                    w.write("&#xD;");
                 }
             }
         } while (++i < len);

--- a/src/test/java/com/ctc/wstx/io/TestTextEscaper.java
+++ b/src/test/java/com/ctc/wstx/io/TestTextEscaper.java
@@ -1,0 +1,52 @@
+package com.ctc.wstx.io;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TextEscaper}, used when serialising StAX2 events to a
+ * raw {@link java.io.Writer} via {@code writeAsEncodedUnicode}.
+ */
+public class TestTextEscaper extends wstxtest.BaseJUnit4Test
+{
+    @Test
+    public void testMarkupAndQuoteEscaping() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        TextEscaper.writeEscapedAttrValue(w, "a<b&c\"d");
+        assertEquals("a&lt;b&amp;c&quot;d", w.toString());
+    }
+
+    // Tab, LF and CR in an attribute value have to be escaped as character
+    // references; left literal they get folded to spaces by attribute-value
+    // normalisation (XML 1.0 #3.3.3) when the document is read back.
+    @Test
+    public void testWhitespaceEscaping() throws Exception
+    {
+        StringWriter w = new StringWriter();
+        TextEscaper.writeEscapedAttrValue(w, "x\ty\nz\rq");
+        assertEquals("x&#x9;y&#xA;z&#xD;q", w.toString());
+    }
+
+    @Test
+    public void testWhitespaceRoundTrip() throws Exception
+    {
+        final String value = "tab\there\nnl\rcr";
+
+        StringWriter w = new StringWriter();
+        TextEscaper.writeEscapedAttrValue(w, value);
+        String doc = "<root attr=\"" + w.toString() + "\"/>";
+
+        XMLInputFactory f = XMLInputFactory.newInstance();
+        XMLStreamReader sr = f.createXMLStreamReader(new StringReader(doc));
+        assertEquals(XMLStreamConstants.START_ELEMENT, sr.next());
+        assertEquals(value, sr.getAttributeValue(0));
+        sr.close();
+    }
+}


### PR DESCRIPTION
Noticed while serialising a StAX2 StartElement event to a Writer: an attribute value holding a tab came back changed after a re-read.

    value    = "a\tb"
    written  = a\tb            (writeAsEncodedUnicode -> writeEscapedAttrValue)
    re-read  = "a b"           (tab folded to a space)

TextEscaper.writeEscapedAttrValue only quotes `<`, `&` and `"`. Tab/LF/CR are written literally, so attribute-value normalisation (XML 1.0 # 3.3.3) collapses them to spaces on the next parse and the value is silently corrupted. The stream writers (BufferingXmlWriter, EncodingXmlWriter) already emit these as character references; this static helper, reached from the event path via SimpleStartElement/CompactStartElement, did not.

Conclusion: escape them as `&#x9;`/`&#xA;`/`&#xD;` so the helper matches the stream writers and round-trips. Added a direct test plus a parse-back check.