### PR TITLE
Reject xml-decl encoding name not matching EncName

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -193,6 +193,8 @@ Aizal Khan (@aizu-m)
  (7.2.2)
 * Contributed #306: Escape tab, newline and CR in `TextEscaper.writeEscapedAttrValue()`
  (7.2.2)
+* Contributed #310: Reject xml-decl encoding name not matching EncName
+ (7.2.2)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -17,6 +17,8 @@ Project: woodstox
 #308: Regression in `NonNsStreamWriter` which causes erroneous `WstxOutputException`
    ("trying to write attribute '***' twice")
  (reported by Joe J)
+#310: Reject xml-decl encoding name not matching EncName
+ (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)
 

--- a/src/main/java/com/ctc/wstx/io/InputBootstrapper.java
+++ b/src/main/java/com/ctc/wstx/io/InputBootstrapper.java
@@ -9,6 +9,7 @@ import com.ctc.wstx.api.ReaderConfig;
 import com.ctc.wstx.cfg.ErrorConsts;
 import com.ctc.wstx.cfg.XmlConsts;
 import com.ctc.wstx.exc.*;
+import com.ctc.wstx.util.StringUtil;
 
 /**
  * Abstract base class that defines common API used with both stream and
@@ -364,10 +365,15 @@ public abstract class InputBootstrapper
                                     null, null);
         }
 
-        if (len < 0) { // will be truncated...
-            return new String(mKeywordBuffer);
+        String enc = (len < 0) // will be truncated...
+            ? new String(mKeywordBuffer) : new String(mKeywordBuffer, 0, len);
+        // 18-Jun-2026: encoding name has to match the XML EncName production
+        //   (XML 1.0 #4.3.3); unlike 'version'/'standalone' it was accepted as-is.
+        if (!StringUtil.isValidEncodingName(enc)) {
+            reportPseudoAttrProblem(XmlConsts.XML_DECL_KW_ENCODING, "'"+enc+"'",
+                                    null, null);
         }
-        return new String(mKeywordBuffer, 0, len);
+        return enc;
     }
 
     private final String readXmlStandalone()

--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -48,6 +48,7 @@ import com.ctc.wstx.exc.WstxException;
 import com.ctc.wstx.io.*;
 import com.ctc.wstx.util.DefaultXmlSymbolTable;
 import com.ctc.wstx.util.ExceptionUtil;
+import com.ctc.wstx.util.StringUtil;
 import com.ctc.wstx.util.TextBuffer;
 import com.ctc.wstx.util.TextBuilder;
 
@@ -2385,10 +2386,13 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                 tb.resetWithEmpty();
                 parseQuoted(XmlConsts.XML_DECL_KW_ENCODING, c, tb);
                 mDocXmlEncoding = tb.toString();
-                /* should we verify encoding at this point? let's not, for now;
-                 * since it's for information only, first declaration from
-                 * bootstrapper is used for the whole stream.
-                 */
+                // Value is for information only, but still has to match the
+                // XML EncName production (XML 1.0 #4.3.3), like the bootstrapper
+                // checks the first declaration.
+                if (!StringUtil.isValidEncodingName(mDocXmlEncoding)) {
+                    throwParseError("Invalid xml '"+XmlConsts.XML_DECL_KW_ENCODING
+                            +"' pseudo-attribute value '"+mDocXmlEncoding+"'");
+                }
                 c = getNextInCurrAfterWS(SUFFIX_IN_XML_DECL);
             } else if (c != 's') {
                 throwUnexpectedChar(c, " in xml declaration; expected either 'encoding' or 'standalone' pseudo-attribute");

--- a/src/main/java/com/ctc/wstx/util/StringUtil.java
+++ b/src/main/java/com/ctc/wstx/util/StringUtil.java
@@ -312,6 +312,37 @@ public final class StringUtil
         return sb.toString();
     }
 
+    /**
+     * Method that verifies that given encoding name matches the XML
+     * <code>EncName</code> production (XML 1.0, section 4.3.3, production
+     * [81]): a Latin letter, optionally followed by Latin letters, ASCII
+     * digits and the characters '.', '_' and '-'.
+     *
+     * @return True if name is a syntactically legal encoding name; false
+     *   if it is empty or contains any character not allowed by EncName
+     */
+    public static boolean isValidEncodingName(String enc)
+    {
+        final int len = enc.length();
+        if (len == 0) {
+            return false;
+        }
+        char c = enc.charAt(0);
+        if (!((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))) {
+            return false;
+        }
+        for (int i = 1; i < len; ++i) {
+            c = enc.charAt(i);
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+                    || (c >= '0' && c <= '9')
+                    || c == '.' || c == '_' || c == '-') {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+
     public static boolean matches(String str, char[] cbuf, int offset, int len)
     {
         if (str.length() != len) {

--- a/src/test/java/wstxtest/stream/TestXmlDeclEncodingName.java
+++ b/src/test/java/wstxtest/stream/TestXmlDeclEncodingName.java
@@ -1,0 +1,73 @@
+package wstxtest.stream;
+
+import java.io.StringReader;
+
+import javax.xml.stream.*;
+
+import org.codehaus.stax2.XMLStreamReader2;
+
+import com.ctc.wstx.api.WstxInputProperties;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the 'encoding' pseudo-attribute of the XML (and text)
+ * declaration is rejected unless it matches the XML 1.0 <code>EncName</code>
+ * production (section 4.3.3). 'version' and 'standalone' were already validated
+ * against their allowed values; 'encoding' used to be accepted verbatim, so via
+ * a Reader source (where the declared name is not otherwise resolved to a
+ * charset) a malformed name was returned by getCharacterEncodingScheme().
+ */
+public class TestXmlDeclEncodingName
+    extends BaseStreamTest
+{
+    @Test
+    public void testValidEncodingNames() throws Exception
+    {
+        // Legal EncName values must keep working unchanged
+        for (String enc : new String[] {
+                "UTF-8", "ISO-8859-1", "US-ASCII", "windows-1252", "Shift_JIS"
+        }) {
+            String xml = "<?xml version='1.0' encoding='"+enc+"'?><root/>";
+            XMLStreamReader2 sr = constructStreamReader(getInputFactory(), xml);
+            assertEquals(enc, sr.getCharacterEncodingScheme());
+            assertTokenType(START_ELEMENT, sr.next());
+            sr.close();
+        }
+    }
+
+    @Test
+    public void testInvalidEncodingNameReader() throws Exception
+    {
+        // leading digit, leading hyphen/dot, embedded space/slash, empty
+        for (String enc : new String[] {
+                "123", "-utf-8", ".weird", "ISO 8859 1", "utf/8", "utf8&", ""
+        }) {
+            String xml = "<?xml version='1.0' encoding='"+enc+"'?><root/>";
+            try {
+                XMLStreamReader sr = getInputFactory()
+                        .createXMLStreamReader(new StringReader(xml));
+                sr.next();
+                sr.close();
+                fail("Expected an exception for illegal encoding name '"+enc+"'");
+            } catch (XMLStreamException expected) {
+                assertTrue("Expected message about 'encoding', got: "+expected.getMessage(),
+                        expected.getMessage().contains("encoding"));
+            }
+        }
+    }
+
+    @Test
+    public void testInvalidEncodingNameMultiDoc() throws Exception
+    {
+        // The 2nd and later declarations of a multi-document stream are parsed
+        // on a separate path; an illegal encoding name there has to fail too.
+        String xml = "<?xml version='1.0'?><root/>"
+            +"<?xml version='1.0' encoding='not valid'?><root/>";
+        XMLInputFactory f = getInputFactory();
+        f.setProperty(WstxInputProperties.P_INPUT_PARSING_MODE,
+                WstxInputProperties.PARSING_MODE_DOCUMENTS);
+        XMLStreamReader sr = constructStreamReader(f, xml);
+        streamThroughFailing(sr, "illegal encoding name in 2nd xml declaration");
+    }
+}


### PR DESCRIPTION
Was reading through the xml declaration parser and noticed `version` and `standalone` get checked against their allowed values, while `encoding` is just stored. Fed a few malformed names through a `StringReader` source:

    encoding="ISO 8859 1"  -> accepted; getCharacterEncodingScheme() = "ISO 8859 1"
    encoding="123"         -> accepted
    encoding="-utf-8"      -> accepted
    encoding=".weird"      -> accepted

Observation: for a Reader source the declared name is never resolved to a charset. `ReaderBootstrapper` only "double-checks" it, and only when an application encoding is also present, so the value survives unchecked all the way to `getCharacterEncodingScheme()`. None of these match the `EncName` production (XML 1.0 #4.3.3, `[A-Za-z] ([A-Za-z0-9._] | '-')*`), so a conformant processor should treat them as a fatal error.

Conclusion: `InputBootstrapper.readXmlEncoding()` needs the same kind of validation `readXmlVersion`/`readXmlStandalone` already do. Grepping for the other declaration parser turned up the same gap in `BasicStreamReader.handleMultiDocXmlDecl()` (the 2nd+ text declarations in multi-document mode), so both call a shared `StringUtil.isValidEncodingName`.

Real charset names (UTF-8, ISO-8859-1, US-ASCII, windows-1252, Shift_JIS, ...) are unaffected. Stream sources already failed a bit later with `UnsupportedEncodingException`; they now fail at the declaration with a clearer message. Added `TestXmlDeclEncodingName` covering the Reader path, the multi-document path and the legal names; it fails on master and passes here. Full suite green (1054).
