### PR TITLE
Reject/fix comment ending in '-' in byte-backed XML writers

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -195,6 +195,8 @@ Aizal Khan (@aizu-m)
  (7.2.2)
 * Contributed #310: Reject xml-decl encoding name not matching EncName
  (7.2.2)
+* Contributed #311: Reject/fix comment ending in '-' in byte-backed XML writers
+ (7.2.2)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -19,6 +19,8 @@ Project: woodstox
  (reported by Joe J)
 #310: Reject xml-decl encoding name not matching EncName
  (contributed by @aizu-m)
+#311: Reject/fix comment ending in '-' in byte-backed XML writers
+ (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)
 

--- a/src/main/java/com/ctc/wstx/sw/AsciiXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/AsciiXmlWriter.java
@@ -527,23 +527,11 @@ public final class AsciiXmlWriter
             }
             len -= max;
         }
-        // A comment may not end with '-' either: the appended "-->" would
-        // otherwise form the illegal "--->" end marker. BufferingXmlWriter
-        // (used for the other encodings) already guards this case.
-        if (data.length() > 0 && data.charAt(data.length()-1) == '-') {
-            if (!mFixContent) {
-                mOutputPtr = ptr;
-                return data.length()-1;
-            }
-            if (ptr >= mOutputBuffer.length) {
-                mOutputPtr = ptr;
-                flushBuffer();
-                ptr = 0;
-            }
-            mOutputBuffer[ptr++] = BYTE_SPACE;
-        }
         mOutputPtr = ptr;
-        return -1;
+        // A comment may not end with '-' either: the appended "-->" would
+        // otherwise form the illegal "--->" end marker (verifyCommentEnd()
+        // rejects or pads it, matching BufferingXmlWriter for other encodings)
+        return verifyCommentEnd(data);
     }
 
     @Override

--- a/src/main/java/com/ctc/wstx/sw/AsciiXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/AsciiXmlWriter.java
@@ -527,6 +527,21 @@ public final class AsciiXmlWriter
             }
             len -= max;
         }
+        // A comment may not end with '-' either: the appended "-->" would
+        // otherwise form the illegal "--->" end marker. BufferingXmlWriter
+        // (used for the other encodings) already guards this case.
+        if (data.length() > 0 && data.charAt(data.length()-1) == '-') {
+            if (!mFixContent) {
+                mOutputPtr = ptr;
+                return data.length()-1;
+            }
+            if (ptr >= mOutputBuffer.length) {
+                mOutputPtr = ptr;
+                flushBuffer();
+                ptr = 0;
+            }
+            mOutputBuffer[ptr++] = BYTE_SPACE;
+        }
         mOutputPtr = ptr;
         return -1;
     }

--- a/src/main/java/com/ctc/wstx/sw/EncodingXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/EncodingXmlWriter.java
@@ -965,6 +965,35 @@ public abstract class EncodingXmlWriter
     protected abstract int writeCommentContent(String data)
         throws IOException;
 
+    /**
+     * Helper method called at the end of {@link #writeCommentContent} to handle
+     * the case where the comment content ends with a hyphen: the trailing '-'
+     * would merge with the appended "-->" to form the illegal "--->" end marker.
+     * Assumes {@link #mOutputPtr} has already been updated to point past the
+     * content written so far.
+     *
+     * @return -1 if the content is valid (or was fixed in place); otherwise the
+     *   index of the illegal trailing hyphen (when not in content-fixing mode)
+     *
+     * @since 7.2.2
+     */
+    protected int verifyCommentEnd(String data)
+        throws IOException
+    {
+        final int ix = data.length() - 1;
+        if (ix >= 0 && data.charAt(ix) == '-') {
+            if (!mFixContent) {
+                return ix;
+            }
+            // Fixable: just pad a single space so "-->" no longer forms "--->"
+            if (mOutputPtr >= mOutputBuffer.length) {
+                flushBuffer();
+            }
+            mOutputBuffer[mOutputPtr++] = BYTE_SPACE;
+        }
+        return -1;
+    }
+
     protected abstract int writePIData(String data)
         throws IOException, XMLStreamException;
 

--- a/src/main/java/com/ctc/wstx/sw/ISOLatin1XmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/ISOLatin1XmlWriter.java
@@ -552,6 +552,21 @@ public final class ISOLatin1XmlWriter
             }
             len -= max;
         }
+        // A comment may not end with '-' either: the appended "-->" would
+        // otherwise form the illegal "--->" end marker. BufferingXmlWriter
+        // (used for the other encodings) already guards this case.
+        if (data.length() > 0 && data.charAt(data.length()-1) == '-') {
+            if (!mFixContent) {
+                mOutputPtr = ptr;
+                return data.length()-1;
+            }
+            if (ptr >= mOutputBuffer.length) {
+                mOutputPtr = ptr;
+                flushBuffer();
+                ptr = 0;
+            }
+            mOutputBuffer[ptr++] = BYTE_SPACE;
+        }
         mOutputPtr = ptr;
         return -1;
     }

--- a/src/main/java/com/ctc/wstx/sw/ISOLatin1XmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/ISOLatin1XmlWriter.java
@@ -552,23 +552,11 @@ public final class ISOLatin1XmlWriter
             }
             len -= max;
         }
-        // A comment may not end with '-' either: the appended "-->" would
-        // otherwise form the illegal "--->" end marker. BufferingXmlWriter
-        // (used for the other encodings) already guards this case.
-        if (data.length() > 0 && data.charAt(data.length()-1) == '-') {
-            if (!mFixContent) {
-                mOutputPtr = ptr;
-                return data.length()-1;
-            }
-            if (ptr >= mOutputBuffer.length) {
-                mOutputPtr = ptr;
-                flushBuffer();
-                ptr = 0;
-            }
-            mOutputBuffer[ptr++] = BYTE_SPACE;
-        }
         mOutputPtr = ptr;
-        return -1;
+        // A comment may not end with '-' either: the appended "-->" would
+        // otherwise form the illegal "--->" end marker (verifyCommentEnd()
+        // rejects or pads it, matching BufferingXmlWriter for other encodings)
+        return verifyCommentEnd(data);
     }
 
     @Override

--- a/src/test/java/wstxtest/wstream/TestContentValidation.java
+++ b/src/test/java/wstxtest/wstream/TestContentValidation.java
@@ -283,12 +283,99 @@ public class TestContentValidation
     
     // // Note: no way (currently?) to fix PI content; thus, no test:
 
+    final String COMMENT_TRAILING_HYPHEN_IN = "comment ends with-";
+    final String COMMENT_TRAILING_HYPHEN_OUT = "comment ends with- ";
+
+    /**
+     * A comment must not end with a hyphen either: the trailing '-' merges
+     * with the appended "-->" to form the illegal "--->" end marker. This is
+     * checked for the StringWriter/UTF-8 paths, but the ISO-8859-1 and
+     * US-ASCII paths use different writer classes.
+     */
+    @Test
+    public void testCommentTrailingHyphenChecking()
+        throws XMLStreamException
+    {
+        for (int i = 0; i <= 2; ++i) {
+            XMLOutputFactory2 f = getFactory(i, true, false);
+            for (int enc = 0; enc < 4; ++enc) {
+                XMLStreamWriter2 sw = createWriter(f, enc, null);
+                sw.writeStartDocument();
+                sw.writeStartElement("root");
+                try {
+                    sw.writeComment(COMMENT_TRAILING_HYPHEN_IN);
+                    fail("Expected an XMLStreamException for comment ending in '-' in checking + non-fixing mode (type "+i+", enc "+enc+")");
+                } catch (XMLStreamException sex) {
+                    // good
+                } catch (Throwable t) {
+                    fail("Expected an XMLStreamException for comment ending in '-' in checking + non-fixing mode; got: "+t);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCommentTrailingHyphenFixing()
+        throws Exception
+    {
+        for (int i = 0; i <= 2; ++i) {
+            XMLOutputFactory2 f = getFactory(i, true, true);
+            for (int enc = 0; enc < 4; ++enc) {
+                ByteArrayOutputStream bos = (enc == 0) ? null : new ByteArrayOutputStream();
+                String encStr = encodingFor(enc);
+                StringWriter strw = (enc == 0) ? new StringWriter() : null;
+                XMLStreamWriter2 sw = createWriter(f, enc, new Object[] { strw, bos });
+                sw.writeStartDocument();
+                sw.writeStartElement("root");
+                sw.writeComment(COMMENT_TRAILING_HYPHEN_IN);
+                sw.writeEndElement();
+                sw.writeEndDocument();
+                sw.close();
+
+                String output = (strw != null) ? strw.toString()
+                    : new String(bos.toByteArray(), encStr);
+
+                // The fixed output must round-trip as a single comment:
+                XMLStreamReader sr = getReader(output);
+                assertTokenType(START_ELEMENT, sr.next());
+                assertTokenType(COMMENT, sr.next());
+                String act = getAndVerifyText(sr);
+                if (!COMMENT_TRAILING_HYPHEN_OUT.equals(act)) {
+                    failStrings("Failed to properly pad comment ending in '-' (type "+i+", enc "+enc+")",
+                                COMMENT_TRAILING_HYPHEN_OUT, act);
+                }
+                assertTokenType(END_ELEMENT, sr.next());
+            }
+        }
+    }
 
     /*
 ////////////////////////////////////////////////////
 // Internal methods
 ////////////////////////////////////////////////////
 */
+
+    // enc: 0 -> StringWriter, 1 -> UTF-8, 2 -> ISO-8859-1, 3 -> US-ASCII
+    private String encodingFor(int enc)
+    {
+        switch (enc) {
+        case 1: return "UTF-8";
+        case 2: return "ISO-8859-1";
+        case 3: return "US-ASCII";
+        default: return null;
+        }
+    }
+
+    private XMLStreamWriter2 createWriter(XMLOutputFactory2 f, int enc, Object[] sinks)
+        throws XMLStreamException
+    {
+        if (enc == 0) {
+            StringWriter strw = (sinks == null) ? new StringWriter() : (StringWriter) sinks[0];
+            return (XMLStreamWriter2) f.createXMLStreamWriter(strw);
+        }
+        ByteArrayOutputStream bos = (sinks == null) ? new ByteArrayOutputStream() : (ByteArrayOutputStream) sinks[1];
+        return (XMLStreamWriter2) f.createXMLStreamWriter(bos, encodingFor(enc));
+    }
 
     private XMLOutputFactory2 getFactory(int type, boolean checkAll, boolean fixAll)
         throws XMLStreamException


### PR DESCRIPTION
AsciiXmlWriter and ISOLatin1XmlWriter only flag an embedded `--` in `writeCommentContent`, so a comment whose content ends in `-` is written as the illegal `--->` end marker (which Woodstox's own reader then rejects), whereas `BufferingXmlWriter` already guards the trailing hyphen for the other encodings; both byte-backed writers now reject it in checking mode and pad a space in fixing mode, matching that path.