### PR TITLE
Bulk-copy plain text runs in readTextSecondary via System.arraycopy

### DIFF
--- a/benchmark/ParseBench.java
+++ b/benchmark/ParseBench.java
@@ -1,0 +1,92 @@
+package com.ctc.wstx.perf;
+
+import java.io.StringReader;
+import java.util.concurrent.TimeUnit;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import com.ctc.wstx.stax.WstxInputFactory;
+
+import org.openjdk.jmh.annotations.*;
+
+/**
+ * End-to-end parse throughput of large, text-heavy XML documents, used to verify
+ * the {@code System.arraycopy} bulk-copy optimization in
+ * {@code BasicStreamReader.readTextSecondary}. Pure Java 8 -- no Vector API.
+ *
+ * <p>Which {@code BasicStreamReader} is exercised is decided by the classpath.
+ * Run once per build and compare the reported ops/s:
+ *
+ * <pre>
+ *   baseline  : -cp benchOut;target/classes;stax2;jmh...
+ *   arraycopy : -cp benchOut;shadow;target/classes;stax2;jmh...   (shadow wins)
+ * </pre>
+ *
+ * <p>Profiles:
+ * <ul>
+ *   <li>{@code entity}  - large text with {@code &amp;} entities -> the COPYING
+ *       path ({@code readTextSecondary}); this is where arraycopy helps.</li>
+ *   <li>{@code prose}   - large plain wrapped text -> the buffer-SHARING path
+ *       ({@code readTextPrimary}, untouched) -> expected neutral.</li>
+ *   <li>{@code records} - many small elements, 2-6 char content -> expected
+ *       neutral.</li>
+ * </ul>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)   // documents parsed per second
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(value = 3, jvmArgs = {"-Xms1g", "-Xmx1g", "-XX:+UseParallelGC",
+        "-Duser.language=en", "-Duser.country=US"})
+public class ParseBench {
+
+    @Param({"prose", "entity", "records"})
+    public String profile;
+
+    String xml;
+    XMLInputFactory factory;
+
+    @Setup
+    public void setup() {
+        xml = buildDoc(profile);
+        factory = new WstxInputFactory();
+        factory.setProperty(XMLInputFactory.IS_COALESCING, Boolean.FALSE);
+    }
+
+    static String buildDoc(String profile) {
+        StringBuilder body = new StringBuilder();
+        if ("records".equals(profile)) {
+            // "Normal" data XML: many small elements, each with short (2-6 char)
+            // text content.
+            String chunk = "<row><a>12</a><b>xyz</b><c>hello</c><d>42</d></row>\n";
+            while (body.length() < 500_000) body.append(chunk);
+            return "<root>" + body + "</root>";
+        }
+        if ("entity".equals(profile)) {
+            String chunk = "some text with an &amp; entity and more words here ";
+            while (body.length() < 500_000) body.append(chunk);
+        } else { // prose: wrapped plain text
+            String chunk = "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do\n";
+            while (body.length() < 500_000) body.append(chunk);
+        }
+        return "<root><big>" + body + "</big></root>";
+    }
+
+    @Benchmark
+    public long parse() throws XMLStreamException {
+        XMLStreamReader r = factory.createXMLStreamReader(new StringReader(xml));
+        long chars = 0;
+        while (r.hasNext()) {
+            int t = r.next();
+            if (t == XMLStreamConstants.CHARACTERS || t == XMLStreamConstants.CDATA) {
+                chars += r.getTextLength();
+            }
+        }
+        r.close();
+        return chars;
+    }
+}

--- a/benchmark/ParseSanity.java
+++ b/benchmark/ParseSanity.java
@@ -1,0 +1,42 @@
+import java.io.StringReader;
+import javax.xml.stream.*;
+import com.ctc.wstx.stax.WstxInputFactory;
+
+public class ParseSanity {
+    static String buildDoc(String profile) {
+        StringBuilder body = new StringBuilder();
+        if ("entity".equals(profile)) {
+            String chunk = "some text with an &amp; entity and more words here ";
+            while (body.length() < 2_000_000) body.append(chunk);
+        } else {
+            String chunk = "Lorem ipsum dolor sit amet consectetur adipiscing elit sed do\n";
+            while (body.length() < 2_000_000) body.append(chunk);
+        }
+        return "<root><big>" + body + "</big></root>";
+    }
+    static long parse(XMLInputFactory f, String xml) throws Exception {
+        XMLStreamReader r = f.createXMLStreamReader(new StringReader(xml));
+        long chars = 0; int events = 0;
+        while (r.hasNext()) { int t = r.next(); events++;
+            if (t==XMLStreamConstants.CHARACTERS||t==XMLStreamConstants.CDATA) chars += r.getTextLength(); }
+        r.close();
+        return (((long)events) << 40) | chars; // pack
+    }
+    public static void main(String[] a) throws Exception {
+        for (String p : new String[]{"prose","entity"}) {
+            String xml = buildDoc(p);
+            XMLInputFactory f = new WstxInputFactory();
+            f.setProperty(XMLInputFactory.IS_COALESCING, Boolean.FALSE);
+            long packed = parse(f, xml); // warm-ish
+            long chars = packed & ((1L<<40)-1); long events = packed >>> 40;
+            long t0 = System.nanoTime();
+            int N = 50;
+            long acc = 0;
+            for (int i=0;i<N;i++) acc += (parse(f, xml) & ((1L<<40)-1));
+            long t1 = System.nanoTime();
+            double msPer = (t1-t0)/1e6/N;
+            System.out.printf("profile=%-6s xmlLen=%d events=%d charsCounted=%d  ->  %.3f ms/parse, %.1f MB/s%n",
+                p, xml.length(), events, chars, msPer, (xml.length()*2/1e6)/(msPer/1000));
+        }
+    }
+}

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,93 @@
+# Bulk `System.arraycopy` optimization for `readTextSecondary`
+
+This branch applies a **Java-8-compatible** optimization to
+`BasicStreamReader.readTextSecondary` (the character-data *copying* path, used
+whenever text contains entities/character references or needs LF conversion):
+instead of copying text one character at a time, it finds the next character
+that needs handling (`firstSpecialTextChar`, a plain scalar scan) and bulk-copies
+the intervening run of "pure" text with a single `System.arraycopy`.
+
+No Vector API, no `jdk.incubator.vector`, no `pom.xml` / Java-version changes —
+this compiles and runs on Java 8. `readTextPrimary` (the zero-copy buffer-sharing
+path) is untouched.
+
+> This is the portable half of a larger SIMD experiment (branch
+> `simd-character-scanning`). That experiment showed the entity/copy-path
+> speedup came almost entirely from this bulk copy — a scalar win — while the
+> Vector-API scan only helped long delimiter-free runs. This branch keeps just
+> the broadly-applicable scalar part.
+
+## Correctness (differential vs master baseline)
+
+The optimized `readTextSecondary` was proven **behavior-preserving** by two
+independent differential harnesses (optimized build vs master baseline, compared
+event-for-event):
+
+- **Structured battery** — 9 tricky documents × {coalescing on/off} × {default,
+  61, 128, 512, 4096}-char buffers = 90 configs: **byte-identical** output
+  (matching MD5), including entities, `&#x1F600;` surrogates, mixed CR/CRLF/LF,
+  CDATA pseudo-terminators, high Unicode, and identical exceptions for the
+  malformed cases (`]]>` in text, control char `0x01`).
+- **Randomized fuzz** — 3000 random documents, 274,496 events, across buffer
+  sizes {31,61,128,509,4096} and both coalescing modes: **identical** strict
+  (per-event) and content digests, 0 divergences.
+
+## Results on this laptop (JDK 25; ratio is what matters)
+
+End-to-end parse throughput (ops/s, `-gc true`; optimized shadow vs master
+baseline, same session). Which `BasicStreamReader` runs is decided by the
+classpath.
+
+| profile | baseline | arraycopy | speedup |
+|---------|---------:|----------:|--------:|
+| **entity** (large text w/ `&amp;` entities → copy path) | 1420 ± 70  | 1848 ± 155 | **1.30x (clear; CIs disjoint)** |
+| prose (large plain text → share path) | 3329 ± 273 | 3231 ± 177 | ~1.0x (parity) |
+| records (many small elements → share path) | 357 ± 25 | 360 ± 32 | ~1.0x (parity) |
+
+The win is concentrated in the **copy path** (`entity`): text with entities or
+CDATA/character references, where the reader must materialize characters into its
+output buffer. `prose` and `records` go through the untouched share path, so they
+are neutral (`records` measured back-to-back to control for thermal drift).
+Baseline throughput drifts run-to-run, so only compare numbers gathered in the
+same session with identical settings.
+
+## Benchmarks
+
+- **`ParseBench`** — end-to-end throughput; profiles `entity` (copy path, where
+  the win is), `prose` and `records` (share path, neutral controls). No Vector API.
+- **`ParseSanity`** — non-JMH wall-clock cross-check (ms/parse, MB/s).
+
+Requires JMH 1.37 (`jmh-core`, `jopt-simple`, `commons-math3`) on the classpath.
+
+## How to build & run
+
+```powershell
+$JDK   = "C:\develop\jdk-25\bin"
+$REPO  = "C:\develop\.m2\repo"
+$STAX2 = "$REPO\org\codehaus\woodstox\stax2-api\4.3.0\stax2-api-4.3.0.jar"
+$JMHC  = "$REPO\org\openjdk\jmh\jmh-core\1.37\jmh-core-1.37.jar"
+$JMHA  = "$REPO\org\openjdk\jmh\jmh-generator-annprocess\1.37\jmh-generator-annprocess-1.37.jar"
+$JOPT  = "$REPO\net\sf\jopt-simple\jopt-simple\5.0.4\jopt-simple-5.0.4.jar"
+$MATH  = "$REPO\org\apache\commons\commons-math3\3.6.1\commons-math3-3.6.1.jar"
+$JMH   = "$JMHC;$JOPT;$MATH"
+
+# 1) Build the optimized reader into a shadow dir (target\classes is the baseline)
+$SHADOW = "$env:TEMP\ac_shadow"
+& "$JDK\javac.exe" -implicit:none -d $SHADOW -cp "target\classes;$STAX2" `
+    "src\main\java\com\ctc\wstx\sr\BasicStreamReader.java"
+
+# 2) Compile the benchmark (annotation processing must be explicit on JDK 23+)
+$BENCH = "$env:TEMP\ac_bench"
+& "$JDK\javac.exe" -proc:full -cp "target\classes;$STAX2;$JMHC;$JMHA" -d $BENCH `
+    benchmark\ParseBench.java
+
+# 3a) BASELINE (target\classes only)
+& "$JDK\java.exe" -cp "$BENCH;target\classes;$STAX2;$JMH" `
+    org.openjdk.jmh.Main "ParseBench" -f 2 -wi 4 -i 8 -gc true
+
+# 3b) OPTIMIZED (shadow first so it wins)
+& "$JDK\java.exe" -cp "$BENCH;$SHADOW;target\classes;$STAX2;$JMH" `
+    org.openjdk.jmh.Main "ParseBench" -f 2 -wi 4 -i 8 -gc true
+```
+
+No `--add-modules` anywhere: this build has no Vector-API dependency.

--- a/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
+++ b/src/main/java/com/ctc/wstx/sr/BasicStreamReader.java
@@ -4616,6 +4616,33 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
     }
 
     /**
+     * Scans a run of XML text content and returns the index in {@code [from, end)}
+     * of the first character that requires per-character handling while reading
+     * character data, or {@code end} if the whole range is "pure" text that can be
+     * copied verbatim.
+     *<p>
+     * The characters that need handling are exactly those the scalar text loop
+     * branches on: control characters ({@code c < 0x20}, which includes
+     * {@code \n}, {@code \r} and {@code \t}), {@code '<'} (segment end),
+     * {@code '&'} (entity) and {@code '>'} (possible {@code ]]>}). Everything else
+     * -- including printable characters below {@link #CHAR_FIRST_PURE_TEXT} such as
+     * space, digits or {@code '='} -- is plain text the loop copies unchanged, so
+     * it is safe to skip here. This lets {@link #readTextSecondary} bulk-copy the
+     * plain run with a single {@link System#arraycopy} instead of one char at a
+     * time.
+     */
+    private static int firstSpecialTextChar(char[] buf, int from, int end)
+    {
+        for (int i = from; i < end; ++i) {
+            char c = buf[i];
+            if (c < CHAR_SPACE || c == '<' || c == '&' || c == '>') {
+                return i;
+            }
+        }
+        return end;
+    }
+
+    /**
      * Method called to read in consecutive beginning parts of a text
      * segment, up to either end of the segment (lt char) or until
      * first 'hole' in text (buffer end, 2-char lf to convert, entity).
@@ -4804,6 +4831,36 @@ currAttrSize, maxAttrSize, outPtr, outBuf.length));
                 inputPtr = mInputPtr;
                 inputBuffer = mInputBuffer;
                 inputLen = mInputEnd;
+            }
+
+            /* Bulk-copy the run of "pure" text characters (those needing no
+             * per-character handling) up to the next special char, honouring
+             * output-segment boundaries exactly as the per-char loop below would.
+             * A single System.arraycopy replaces the per-character copy for the
+             * common case of long runs of plain text (large text/CDATA nodes).
+             */
+            {
+                int runEnd = firstSpecialTextChar(inputBuffer, inputPtr, inputLen);
+                while (inputPtr < runEnd) {
+                    int n = runEnd - inputPtr;
+                    int room = outBuf.length - outPtr;
+                    if (n > room) {
+                        n = room;
+                    }
+                    System.arraycopy(inputBuffer, inputPtr, outBuf, outPtr, n);
+                    inputPtr += n;
+                    outPtr += n;
+                    if (outPtr >= outBuf.length) { // filled the segment
+                        if ((outBuf = _expandOutputForText(inputPtr, outBuf, shortestSegment)) == null) {
+                            return false;
+                        }
+                        verifyLimit("Text size", mConfig.getMaxTextLength(), mTextBuffer.size());
+                        outPtr = 0;
+                    }
+                }
+                if (inputPtr >= inputLen) { // consumed all buffered input; reload
+                    continue;
+                }
             }
             char c = inputBuffer[inputPtr++];
 


### PR DESCRIPTION
See #313: Draft pull request with all the heavy lifting done by Claude Code

Replace the per-character copy loop in `BasicStreamReader.readTextSecondary` with a `scan (firstSpecialTextChar)` + single `System.arraycopy` of each run of "pure" text (no `<`, `&`, `>`, or control chars), honouring output-segment boundaries exactly as before. `readTextPrimary` (the zero-copy sharing path) is unchanged.

Pure Java 8: no Vector API, no `jdk.incubator.vector`, no pom/Java-version changes. This is the portable, broadly-applicable scalar half of a SIMD experiment; the copy-path speedup there was shown to come from this bulk copy rather than the vectorized scan.

Verified behavior-preserving vs. master by two differential harnesses:
- structured battery: 9 docs x {coalescing} x {5 buffer sizes} = 90 configs, byte-identical output incl. entities, surrogates, CR/CRLF/LF, CDATA pseudo-terminators, and identical exceptions for malformed input.
- randomized fuzz: 3000 docs / 274,496 events, identical event digests.

Benchmark (JDK 25, end-to-end parse, Meteor Lake laptop): entity/copy-path workload ~1.30x faster (1420 -> 1848 ops/s, disjoint CIs); prose and records (share path) at parity. See benchmark/README.md.

Closes #313 