### PR TITLE
Reject U+009F in xml 1.1 unescapable content in `ISOLatin1XmlWriter`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -197,6 +197,8 @@ Aizal Khan (@aizu-m)
  (7.2.2)
 * Contributed #311: Reject/fix comment ending in '-' in byte-backed XML writers
  (7.2.2)
+* Contributed #316: Reject U+009F in xml 1.1 unescapable content in `ISOLatin1XmlWriter`
+ (7.2.2)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -21,6 +21,8 @@ Project: woodstox
  (contributed by @aizu-m)
 #311: Reject/fix comment ending in '-' in byte-backed XML writers
  (contributed by @aizu-m)
+#316: Reject U+009F in xml 1.1 unescapable content in `ISOLatin1XmlWriter`
+ (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -22,6 +22,8 @@ Project: woodstox
 #311: Reject/fix comment ending in '-' in byte-backed XML writers
  (contributed by @aizu-m)
 #316: Reject U+009F in xml 1.1 unescapable content in `ISOLatin1XmlWriter`
+  (also fix `ISOLatin1XmlWriter` and `AsciiXmlWriter` writing already-flushed output
+   a second time, when a replacing `InvalidCharHandler` is configured)
  (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)

--- a/src/main/java/com/ctc/wstx/sw/AsciiXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/AsciiXmlWriter.java
@@ -67,6 +67,7 @@ public final class AsciiXmlWriter
                         } else if (c != '\t') {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
+                            ptr = mOutputPtr;
                         }
                     } else if (c > 0x7E) {
                         mOutputPtr = ptr;
@@ -74,6 +75,7 @@ public final class AsciiXmlWriter
                             handleInvalidAsciiChar(c);
                         } else if (mXml11) {
                             c = handleInvalidChar(c);
+                            ptr = mOutputPtr;
                         }
                     }
                     mOutputBuffer[ptr++] = (byte) c;
@@ -119,6 +121,7 @@ public final class AsciiXmlWriter
                         } else if (c != '\t') {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
+                            ptr = mOutputPtr;
                         }
                     } else if (c > 0x7E) {
                         mOutputPtr = ptr;
@@ -126,6 +129,7 @@ public final class AsciiXmlWriter
                             handleInvalidAsciiChar(c);
                         } else if (mXml11) {
                             c = handleInvalidChar(c);
+                            ptr = mOutputPtr;
                         }
                     }
                     mOutputBuffer[ptr++] = (byte) c;
@@ -185,7 +189,9 @@ public final class AsciiXmlWriter
                     } else if (c != '\n' && c != '\t') {
                         if (mCheckContent) {
                             if (!mXml11 || c == 0) {
+                                mOutputPtr = ptr;
                                 c = handleInvalidChar(c);
+                                ptr = mOutputPtr;
                                 mOutputBuffer[ptr++] = (byte) c;
                                 continue;
                             }
@@ -266,7 +272,9 @@ public final class AsciiXmlWriter
                     } else if (c != '\n' && c != '\t') {
                         if (mCheckContent) {
                             if (!mXml11 || c == 0) {
+                                mOutputPtr = ptr;
                                 c = handleInvalidChar(c);
+                                ptr = mOutputPtr;
                                 mOutputBuffer[ptr++] = (byte) c;
                                 continue;
                             }
@@ -341,6 +349,7 @@ public final class AsciiXmlWriter
                     } else if (c != '\t') {
                         mOutputPtr = ptr;
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c > 0x7E) {
                     mOutputPtr = ptr;
@@ -348,6 +357,7 @@ public final class AsciiXmlWriter
                         handleInvalidAsciiChar(c);
                     } else if (mXml11) {
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c == '>') { // embedded "]]>"?
                     if (offset > 2 && data.charAt(offset-2) == ']'
@@ -415,6 +425,7 @@ public final class AsciiXmlWriter
                     } else if (c != '\t') {
                         mOutputPtr = ptr;
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c > 0x7E) {
                     mOutputPtr = ptr;
@@ -422,6 +433,7 @@ public final class AsciiXmlWriter
                         handleInvalidAsciiChar(c);
                     } else if (mXml11) {
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c == '>') { // embedded "]]>"?
                     if (offset >= (start+3) && cbuf[offset-2] == ']'
@@ -490,6 +502,7 @@ public final class AsciiXmlWriter
                     } else if (c != '\t') {
                         mOutputPtr = ptr;
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c > 0x7E) {
                     mOutputPtr = ptr;
@@ -497,6 +510,7 @@ public final class AsciiXmlWriter
                         handleInvalidAsciiChar(c);
                     } else if (mXml11) {
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c == '-') { // embedded "--"?
                     if (offset > 1 && data.charAt(offset-2) == '-') {
@@ -570,6 +584,7 @@ public final class AsciiXmlWriter
                     } else if (c != '\t') {
                         mOutputPtr = ptr;
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c > 0x7E) {
                     mOutputPtr = ptr;
@@ -577,6 +592,7 @@ public final class AsciiXmlWriter
                         handleInvalidAsciiChar(c);
                     } else if (mXml11) {
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c == '>') { // enclosed end marker ("?>")?
                     if (offset > 0 && data.charAt(offset-1) == '?') {

--- a/src/main/java/com/ctc/wstx/sw/ISOLatin1XmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/ISOLatin1XmlWriter.java
@@ -77,7 +77,7 @@ public final class ISOLatin1XmlWriter
                             mOutputPtr = ptr;
                             handleInvalidLatinChar(c);
                         } else if (mXml11) {
-                            if (c < 0x9F && c != 0x85) {
+                            if (c <= 0x9F && c != 0x85) {
                                 mOutputPtr = ptr;
                                 c = handleInvalidChar(c);
                             }
@@ -132,7 +132,7 @@ public final class ISOLatin1XmlWriter
                             mOutputPtr = ptr;
                             handleInvalidLatinChar(c);
                         } else if (mXml11) {
-                            if (c < 0x9F && c != 0x85) {
+                            if (c <= 0x9F && c != 0x85) {
                                 mOutputPtr = ptr;
                                 c = handleInvalidChar(c);
                             }
@@ -363,7 +363,7 @@ public final class ISOLatin1XmlWriter
                         mOutputPtr = ptr;
                         handleInvalidLatinChar(c);
                     } else if (mXml11) {
-                        if (c < 0x9F && c != 0x85) {
+                        if (c <= 0x9F && c != 0x85) {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
                         }
@@ -440,7 +440,7 @@ public final class ISOLatin1XmlWriter
                         mOutputPtr = ptr;
                         handleInvalidLatinChar(c);
                     } else if (mXml11) {
-                        if (c < 0x9F && c != 0x85) {
+                        if (c <= 0x9F && c != 0x85) {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
                         }
@@ -518,7 +518,7 @@ public final class ISOLatin1XmlWriter
                         mOutputPtr = ptr;
                         handleInvalidLatinChar(c);
                     } else if (mXml11) {
-                        if (c < 0x9F && c != 0x85) {
+                        if (c <= 0x9F && c != 0x85) {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
                         }
@@ -601,7 +601,7 @@ public final class ISOLatin1XmlWriter
                         mOutputPtr = ptr;
                         handleInvalidLatinChar(c);
                     } else if (mXml11) {
-                        if (c < 0x9F && c != 0x85) {
+                        if (c <= 0x9F && c != 0x85) {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
                         }

--- a/src/main/java/com/ctc/wstx/sw/ISOLatin1XmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/ISOLatin1XmlWriter.java
@@ -71,6 +71,7 @@ public final class ISOLatin1XmlWriter
                         } else if (c != '\t') {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
+                            ptr = mOutputPtr;
                         }
                     } else if (c > 0x7E) {
                         if (c > 0xFF) {
@@ -80,6 +81,7 @@ public final class ISOLatin1XmlWriter
                             if (c <= 0x9F && c != 0x85) {
                                 mOutputPtr = ptr;
                                 c = handleInvalidChar(c);
+                                ptr = mOutputPtr;
                             }
                         }
                     }
@@ -126,6 +128,7 @@ public final class ISOLatin1XmlWriter
                         } else if (c != '\t') {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
+                            ptr = mOutputPtr;
                         }
                     } else if (c > 0x7E) {
                         if (c > 0xFF) {
@@ -135,6 +138,7 @@ public final class ISOLatin1XmlWriter
                             if (c <= 0x9F && c != 0x85) {
                                 mOutputPtr = ptr;
                                 c = handleInvalidChar(c);
+                                ptr = mOutputPtr;
                             }
                         }
                     }
@@ -195,7 +199,9 @@ public final class ISOLatin1XmlWriter
                     } else if (c != '\n' && c != '\t') {
                         if (mCheckContent) {
                             if (!mXml11 || c == 0) {
+                                mOutputPtr = ptr;
                                 c = handleInvalidChar(c);
+                                ptr = mOutputPtr;
                                 mOutputBuffer[ptr++] = (byte) c;
                                 continue;
                             }
@@ -279,7 +285,9 @@ public final class ISOLatin1XmlWriter
                     } else if (c != '\n' && c != '\t') {
                         if (mCheckContent) {
                             if (!mXml11 || c == 0) {
+                                mOutputPtr = ptr;
                                 c = handleInvalidChar(c);
+                                ptr = mOutputPtr;
                                 mOutputBuffer[ptr++] = (byte) c;
                                 continue;
                             }
@@ -357,6 +365,7 @@ public final class ISOLatin1XmlWriter
                     } else if (c != '\t') {
                         mOutputPtr = ptr;
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c > 0x7E) {
                     if (c > 0xFF) {
@@ -366,6 +375,7 @@ public final class ISOLatin1XmlWriter
                         if (c <= 0x9F && c != 0x85) {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
+                            ptr = mOutputPtr;
                         }
                     }
                 } else if (c == '>') { // embedded "]]>"?
@@ -434,6 +444,7 @@ public final class ISOLatin1XmlWriter
                     } else if (c != '\t') {
                         mOutputPtr = ptr;
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c > 0x7E) {
                     if (c > 0xFF) {
@@ -443,6 +454,7 @@ public final class ISOLatin1XmlWriter
                         if (c <= 0x9F && c != 0x85) {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
+                            ptr = mOutputPtr;
                         }
                     }
                 } else if (c == '>') { // embedded "]]>"?
@@ -512,6 +524,7 @@ public final class ISOLatin1XmlWriter
                     } else if (c != '\t') {
                         mOutputPtr = ptr;
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c > 0x7E) {
                     if (c > 0xFF) {
@@ -521,6 +534,7 @@ public final class ISOLatin1XmlWriter
                         if (c <= 0x9F && c != 0x85) {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
+                            ptr = mOutputPtr;
                         }
                     }
                 } else if (c == '-') { // embedded "--"?
@@ -595,6 +609,7 @@ public final class ISOLatin1XmlWriter
                     } else if (c != '\t') {
                         mOutputPtr = ptr;
                         c = handleInvalidChar(c);
+                        ptr = mOutputPtr;
                     }
                 } else if (c > 0x7E) {
                     if (c > 0xFF) {
@@ -604,6 +619,7 @@ public final class ISOLatin1XmlWriter
                         if (c <= 0x9F && c != 0x85) {
                             mOutputPtr = ptr;
                             c = handleInvalidChar(c);
+                            ptr = mOutputPtr;
                         }
                     }
                 } else if (c == '>') { // enclosed end marker ("?>")?

--- a/src/test/java/wstxtest/wstream/TestContentValidation.java
+++ b/src/test/java/wstxtest/wstream/TestContentValidation.java
@@ -349,6 +349,84 @@ public class TestContentValidation
         }
     }
 
+    /**
+     * U+009F is a restricted character in XML 1.1 (like the rest of the C1
+     * range 0x7F-0x9F, bar NEL 0x85). In comment/CDATA/PI content it can not
+     * be escaped, so the ISO-8859-1 writer must reject it. The C1 rejection
+     * range in ISOLatin1XmlWriter used '<' where the reader (ISOLatinReader)
+     * and every sibling check use '<=', so 0x9F alone slipped through and was
+     * emitted as a raw byte, which the reader then refuses.
+     */
+    @Test
+    public void testXml11RestrictedC1InIsoLatin1()
+        throws XMLStreamException
+    {
+        // 0x9F must be rejected; 0x9E is the adjacent already-rejected control
+        for (int c1 = 0x9E; c1 <= 0x9F; ++c1) {
+            for (int i = 0; i <= 2; ++i) {
+                XMLOutputFactory2 f = getFactory(i, true, false);
+                for (int kind = 0; kind < 4; ++kind) {
+                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                    XMLStreamWriter2 sw = (XMLStreamWriter2) f.createXMLStreamWriter(bos, "ISO-8859-1");
+                    sw.writeStartDocument("ISO-8859-1", "1.1");
+                    sw.writeStartElement("root");
+                    String content = "x" + ((char) c1) + "y";
+                    try {
+                        switch (kind) {
+                        case 0:
+                            sw.writeComment(content);
+                            break;
+                        case 1:
+                            sw.writeCData(content);
+                            break;
+                        case 2:
+                            char[] ch = content.toCharArray();
+                            sw.writeCData(ch, 0, ch.length);
+                            break;
+                        default:
+                            sw.writeProcessingInstruction("target", content);
+                            break;
+                        }
+                        fail("Expected an XMLStreamException for restricted XML 1.1 char U+00"
+                                +Integer.toHexString(c1).toUpperCase()
+                                +" in unescapable ISO-8859-1 content (type "+i+", kind "+kind+")");
+                    } catch (XMLStreamException sex) {
+                        // good
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * The fix above must not touch valid ISO-8859-1 chars (0xA0-0xFF), which
+     * remain legal literal XML 1.1 content.
+     */
+    @Test
+    public void testXml11ValidHighLatin1Unaffected()
+        throws Exception
+    {
+        for (int i = 0; i <= 2; ++i) {
+            XMLOutputFactory2 f = getFactory(i, true, false);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            XMLStreamWriter2 sw = (XMLStreamWriter2) f.createXMLStreamWriter(bos, "ISO-8859-1");
+            sw.writeStartDocument("ISO-8859-1", "1.1");
+            sw.writeStartElement("root");
+            String content = "x éÿy"; // NBSP, e-acute, y-diaeresis
+            sw.writeCData(content);
+            sw.writeEndElement();
+            sw.writeEndDocument();
+            sw.close();
+
+            XMLStreamReader sr = getReader(new String(bos.toByteArray(), "ISO-8859-1"));
+            assertTokenType(START_ELEMENT, sr.next());
+            assertTokenType(CDATA, sr.next());
+            if (!content.equals(getAndVerifyText(sr))) {
+                fail("Valid high ISO-8859-1 CDATA content was altered (type "+i+")");
+            }
+        }
+    }
+
     /*
 ////////////////////////////////////////////////////
 // Internal methods

--- a/src/test/java/wstxtest/wstream/TestContentValidation.java
+++ b/src/test/java/wstxtest/wstream/TestContentValidation.java
@@ -23,6 +23,18 @@ public class TestContentValidation
     final String PI_CONTENT_IN = "this should end PI: ?> shouldn't it?";
     final String PI_CONTENT_OUT = "this should end PI: ?> shouldn't it?";
 
+    /**
+     * NEL: the one char in 0x7F-0x9F that XML 1.1 does <b>not</b> restrict.
+     */
+    final static int NEL = 0x85;
+
+    /**
+     * Number of content types that can not use character entities, and thus
+     * have to reject restricted chars outright; see
+     * {@link #writeUnescapable}.
+     */
+    final static int UNESCAPABLE_KINDS = 6;
+
     /*
     ////////////////////////////////////////////////////
     // Main test methods
@@ -350,43 +362,29 @@ public class TestContentValidation
     }
 
     /**
-     * U+009F is a restricted character in XML 1.1 (like the rest of the C1
-     * range 0x7F-0x9F, bar NEL 0x85). In comment/CDATA/PI content it can not
-     * be escaped, so the ISO-8859-1 writer must reject it. The C1 rejection
-     * range in ISOLatin1XmlWriter used '<' where the reader (ISOLatinReader)
-     * and every sibling check use '<=', so 0x9F alone slipped through and was
-     * emitted as a raw byte, which the reader then refuses.
+     * [woodstox-core#316]: U+009F is a restricted character in XML 1.1, as is
+     * the rest of the C1 range 0x7F-0x9F bar NEL (0x85). In comment, CDATA, PI
+     * and raw content it can not be replaced by a character entity, so the
+     * ISO-8859-1 writer has to reject it. The C1 check in
+     * {@code ISOLatin1XmlWriter} used '&lt;' where the matching reader-side
+     * check ({@code ISOLatinReader}) uses '&lt;=', so 0x9F alone slipped
+     * through and was emitted as a raw byte -- output that Woodstox itself
+     * then refuses to read.
      */
     @Test
     public void testXml11RestrictedC1InIsoLatin1()
         throws XMLStreamException
     {
-        // 0x9F must be rejected; 0x9E is the adjacent already-rejected control
-        for (int c1 = 0x9E; c1 <= 0x9F; ++c1) {
+        for (int c1 = 0x7F; c1 <= 0x9F; ++c1) {
+            if (c1 == NEL) { // not restricted; see testXml11NelNotRejectedInIsoLatin1()
+                continue;
+            }
             for (int i = 0; i <= 2; ++i) {
                 XMLOutputFactory2 f = getFactory(i, true, false);
-                for (int kind = 0; kind < 4; ++kind) {
-                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                    XMLStreamWriter2 sw = (XMLStreamWriter2) f.createXMLStreamWriter(bos, "ISO-8859-1");
-                    sw.writeStartDocument("ISO-8859-1", "1.1");
-                    sw.writeStartElement("root");
-                    String content = "x" + ((char) c1) + "y";
+                for (int kind = 0; kind < UNESCAPABLE_KINDS; ++kind) {
+                    XMLStreamWriter2 sw = startXml11Latin1Doc(f, new ByteArrayOutputStream());
                     try {
-                        switch (kind) {
-                        case 0:
-                            sw.writeComment(content);
-                            break;
-                        case 1:
-                            sw.writeCData(content);
-                            break;
-                        case 2:
-                            char[] ch = content.toCharArray();
-                            sw.writeCData(ch, 0, ch.length);
-                            break;
-                        default:
-                            sw.writeProcessingInstruction("target", content);
-                            break;
-                        }
+                        writeUnescapable(sw, kind, "x" + ((char) c1) + "y");
                         fail("Expected an XMLStreamException for restricted XML 1.1 char U+00"
                                 +Integer.toHexString(c1).toUpperCase()
                                 +" in unescapable ISO-8859-1 content (type "+i+", kind "+kind+")");
@@ -399,8 +397,34 @@ public class TestContentValidation
     }
 
     /**
-     * The fix above must not touch valid ISO-8859-1 chars (0xA0-0xFF), which
-     * remain legal literal XML 1.1 content.
+     * NEL (U+0085) is deliberately excluded from the XML 1.1 restricted range,
+     * so it must keep being written literally: the [woodstox-core#316] fix
+     * widened the rejected range by one character and must not widen it by two.
+     */
+    @Test
+    public void testXml11NelNotRejectedInIsoLatin1()
+        throws Exception
+    {
+        for (int i = 0; i <= 2; ++i) {
+            XMLOutputFactory2 f = getFactory(i, true, false);
+            for (int kind = 0; kind < UNESCAPABLE_KINDS; ++kind) {
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                XMLStreamWriter2 sw = startXml11Latin1Doc(f, bos);
+                writeUnescapable(sw, kind, "x" + ((char) NEL) + "y");
+                sw.writeEndElement();
+                sw.writeEndDocument();
+                sw.close();
+
+                if (indexOfByte(bos.toByteArray(), NEL) < 0) {
+                    fail("NEL (U+0085) not written literally in XML 1.1 ISO-8859-1 output (type "+i+", kind "+kind+")");
+                }
+            }
+        }
+    }
+
+    /**
+     * The [woodstox-core#316] fix must not touch valid ISO-8859-1 chars
+     * (0xA0-0xFF), which remain legal literal XML 1.1 content.
      */
     @Test
     public void testXml11ValidHighLatin1Unaffected()
@@ -409,16 +433,24 @@ public class TestContentValidation
         for (int i = 0; i <= 2; ++i) {
             XMLOutputFactory2 f = getFactory(i, true, false);
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            XMLStreamWriter2 sw = (XMLStreamWriter2) f.createXMLStreamWriter(bos, "ISO-8859-1");
-            sw.writeStartDocument("ISO-8859-1", "1.1");
-            sw.writeStartElement("root");
-            String content = "x éÿy"; // NBSP, e-acute, y-diaeresis
+            XMLStreamWriter2 sw = startXml11Latin1Doc(f, bos);
+            // NBSP, e-acute, y-diaeresis (escaped to keep this file pure ASCII)
+            final String content = "x\u00A0\u00E9\u00FFy";
             sw.writeCData(content);
             sw.writeEndElement();
             sw.writeEndDocument();
             sw.close();
 
-            XMLStreamReader sr = getReader(new String(bos.toByteArray(), "ISO-8859-1"));
+            // Must be emitted as single literal bytes, not escaped or replaced
+            byte[] doc = bos.toByteArray();
+            for (int ch : new int[] { 0xA0, 0xE9, 0xFF }) {
+                if (indexOfByte(doc, ch) < 0) {
+                    fail("Valid high ISO-8859-1 char 0x"+Integer.toHexString(ch)
+                            +" missing from raw XML 1.1 output (type "+i+")");
+                }
+            }
+
+            XMLStreamReader sr = getReader(new String(doc, "ISO-8859-1"));
             assertTokenType(START_ELEMENT, sr.next());
             assertTokenType(CDATA, sr.next());
             if (!content.equals(getAndVerifyText(sr))) {
@@ -473,6 +505,57 @@ public class TestContentValidation
         XMLInputFactory2 f = getInputFactory();
         setCoalescing(f, false);
         return f.createXMLStreamReader(new StringReader(content));
+    }
+
+    private XMLStreamWriter2 startXml11Latin1Doc(XMLOutputFactory2 f, ByteArrayOutputStream bos)
+        throws XMLStreamException
+    {
+        XMLStreamWriter2 sw = (XMLStreamWriter2) f.createXMLStreamWriter(bos, "ISO-8859-1");
+        sw.writeStartDocument("ISO-8859-1", "1.1");
+        sw.writeStartElement("root");
+        return sw;
+    }
+
+    /**
+     * Writes given content as one of the content types that can not fall back
+     * on character entities; covers both the String and char[] variants, since
+     * writers implement them separately.
+     */
+    private void writeUnescapable(XMLStreamWriter2 sw, int kind, String content)
+        throws XMLStreamException
+    {
+        char[] ch = content.toCharArray();
+
+        switch (kind) {
+        case 0:
+            sw.writeComment(content);
+            break;
+        case 1:
+            sw.writeCData(content);
+            break;
+        case 2:
+            sw.writeCData(ch, 0, ch.length);
+            break;
+        case 3:
+            sw.writeProcessingInstruction("target", content);
+            break;
+        case 4:
+            sw.writeRaw(content);
+            break;
+        default:
+            sw.writeRaw(ch, 0, ch.length);
+            break;
+        }
+    }
+
+    private int indexOfByte(byte[] data, int b)
+    {
+        for (int i = 0; i < data.length; ++i) {
+            if ((data[i] & 0xFF) == b) {
+                return i;
+            }
+        }
+        return -1;
     }
 }
 

--- a/src/test/java/wstxtest/wstream/TestInvalidChars.java
+++ b/src/test/java/wstxtest/wstream/TestInvalidChars.java
@@ -184,6 +184,61 @@ public class TestInvalidChars
         doTestXml11UnescapableInvalidIsReplaced(PROCESSING_INSTRUCTION);
     }
 
+    /**
+     * [woodstox-core#316]: the byte-backed writers scan content keeping the
+     * output position in a local {@code ptr}, but {@code handleInvalidChar()}
+     * flushes the buffer underneath them (resetting {@code mOutputPtr} to 0).
+     * {@code ptr} was not reloaded afterwards, so everything flushed up to that
+     * point got written out a second time. Only visible with a non-throwing
+     * {@link InvalidCharHandler}: the default one throws instead of returning,
+     * so the writer never continued past the flush.
+     */
+    @Test
+    public void testReplacingDoesNotDuplicateOutput() throws Exception
+    {
+        for (String enc : new String[] { "ISO-8859-1", "US-ASCII" }) {
+            for (int evtType : new int[] { ATTRIBUTE, CHARACTERS, CDATA, COMMENT,
+                    PROCESSING_INSTRUCTION }) {
+                XMLOutputFactory2 f = getFactory(REPL_CHAR);
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                XMLStreamWriter2 sw = (XMLStreamWriter2) f.createXMLStreamWriter(bos, enc);
+                sw.writeStartDocument(enc, "1.0");
+                sw.writeStartElement("root");
+                switch (evtType) {
+                case ATTRIBUTE:
+                    sw.writeAttribute("attr", INVALID_TEXT);
+                    break;
+                case CHARACTERS:
+                    sw.writeCharacters(INVALID_TEXT);
+                    break;
+                default:
+                    writeUnescapable(sw, evtType);
+                    break;
+                }
+                sw.writeEndElement();
+                sw.writeEndDocument();
+                sw.closeCompletely();
+
+                String doc = bos.toString(enc);
+                String desc = tokenTypeDesc(evtType) + "/" + enc;
+
+                if (doc.indexOf(REPL_CHAR) < 0) {
+                    fail(desc+": expected replacement '"+REPL_CHAR+"' in output. Got: '"+doc+"'");
+                }
+                // Prefix flushed before the replacement must not be re-emitted
+                assertEquals(desc+": xml declaration written more than once: '"+doc+"'",
+                        doc.indexOf("<?xml"), doc.lastIndexOf("<?xml"));
+                // ... and the result must still be well-formed
+                XMLStreamReader sr = getInputFactory().createXMLStreamReader(
+                        new ByteArrayInputStream(doc.getBytes(enc)));
+                while (sr.hasNext()) {
+                    sr.next();
+                }
+                sr.close();
+            }
+        }
+    }
+
     private void doTestXml11UnescapableInvalidIsCaught(int evtType) throws Exception
     {
         XMLOutputFactory2 f = getFactory(null);


### PR DESCRIPTION
Writing an XML 1.1 document through the ISO-8859-1 backend, content checking on. A CDATA section holding U+009F comes out with a literal 0x9F byte, and Woodstox's own reader then rejects what it just wrote:

    Invalid character 0x9f, can only be included in xml 1.1 using
    character entities (at char #60, byte #60)

Traced it to the C1 rejection in ISOLatin1XmlWriter. Unescapable content (comment, CDATA, PI, raw) refuses the XML 1.1 restricted range 0x7F-0x9F with `if (c < 0x9F && c != 0x85)`. The bound is exclusive, so 0x9F alone falls through and is emitted raw.

ISOLatinReader gates the same range with `c <= 0x9F`, and so does every other C1 check in the tree (UTF8Reader, UTF32Reader, EBCDICCodec, InvalidCharHandler). The writer was the lone outlier.

Changed the six sites to `c <= 0x9F`. Valid 0xA0-0xFF stay untouched, and the escapable text/attribute path already writes 0x9F as a character reference, so only the unescapable byte path changes.
