### PR TITLE
Encode DOCTYPE root name in `EncodingXmlWriter.writeDTD()`

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -197,6 +197,8 @@ Aizal Khan (@aizu-m)
  (7.2.2)
 * Contributed #311: Reject/fix comment ending in '-' in byte-backed XML writers
  (7.2.2)
+* Contributed #318: Encode DOCTYPE root name in `EncodingXmlWriter.writeDTD()`
+ (7.2.2)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -21,6 +21,8 @@ Project: woodstox
  (contributed by @aizu-m)
 #311: Reject/fix comment ending in '-' in byte-backed XML writers
  (contributed by @aizu-m)
+#318: Encode DOCTYPE root name in `EncodingXmlWriter.writeDTD()`
+ (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)
 

--- a/src/main/java/com/ctc/wstx/sw/EncodingXmlWriter.java
+++ b/src/main/java/com/ctc/wstx/sw/EncodingXmlWriter.java
@@ -328,7 +328,11 @@ public abstract class EncodingXmlWriter
         throws IOException, XMLStreamException
     {
         writeAscii("<!DOCTYPE ");
-        writeAscii(rootName);
+        if (mCheckNames) {
+            // Root name may be prefixed, so colon count is not checked
+            verifyNameValidity(rootName, false);
+        }
+        writeRaw(rootName, 0, rootName.length());
         if (systemId != null) {
             if (publicId != null) {
                 writeAscii(" PUBLIC \"");

--- a/src/test/java/wstxtest/wstream/TestNameValidation.java
+++ b/src/test/java/wstxtest/wstream/TestNameValidation.java
@@ -416,6 +416,53 @@ public class TestNameValidation
     }
 
     /**
+     * The DOCTYPE root name has to go through the same encoding checks as
+     * element names: with the byte-backed writers (US-ASCII, ISO-8859-1)
+     * a character the encoding can not represent must be reported, not
+     * silently truncated to its low byte.
+     */
+    @Test
+    public void testRootNameNotInEncoding()
+        throws Exception
+    {
+        // 0x13E would truncate to 0x3E ('>'), 0x13C to 0x3C ('<')
+        final String rootName = "rľļ";
+
+        for (String enc : new String[] { "US-ASCII", "ISO-8859-1" }) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            XMLStreamWriter2 sw = (XMLStreamWriter2) getFactory(true, true)
+                .createXMLStreamWriter(bos, enc);
+            try {
+                sw.writeDTD(rootName, null, null, null);
+                sw.flush();
+                fail("Expected failure for root name not representable in "+enc
+                     +"; instead got output '"+new String(bos.toByteArray(), "ISO-8859-1")+"'");
+            } catch (XMLStreamException sex) {
+                verifyException(sex, "Invalid XML character");
+            }
+        }
+    }
+
+    /**
+     * Counterpart of {@link #testRootNameNotInEncoding}: a root name the
+     * encoding does cover has to be written as is.
+     */
+    @Test
+    public void testRootNameInEncoding()
+        throws Exception
+    {
+        final String rootName = "ré";
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        XMLStreamWriter2 sw = (XMLStreamWriter2) getFactory(true, true)
+            .createXMLStreamWriter(bos, "ISO-8859-1");
+        sw.writeDTD(rootName, null, null, null);
+        sw.writeEmptyElement(rootName);
+        sw.close();
+        assertEquals("<!DOCTYPE "+rootName+"><"+rootName+"/>",
+                     new String(bos.toByteArray(), "ISO-8859-1"));
+    }
+
+    /**
      * According to XML Namespaces 1.1 specification, entity names (ids)
      * can not contain colons either...
      *<p>

--- a/src/test/java/wstxtest/wstream/TestNameValidation.java
+++ b/src/test/java/wstxtest/wstream/TestNameValidation.java
@@ -420,6 +420,10 @@ public class TestNameValidation
      * element names: with the byte-backed writers (US-ASCII, ISO-8859-1)
      * a character the encoding can not represent must be reported, not
      * silently truncated to its low byte.
+     *<p>
+     * Note: the check is on the encoding, not on name well-formedness, so
+     * it has to apply with name validation disabled too (which is the
+     * default setting).
      */
     @Test
     public void testRootNameNotInEncoding()
@@ -428,17 +432,20 @@ public class TestNameValidation
         // 0x13E would truncate to 0x3E ('>'), 0x13C to 0x3C ('<')
         final String rootName = "rľļ";
 
-        for (String enc : new String[] { "US-ASCII", "ISO-8859-1" }) {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            XMLStreamWriter2 sw = (XMLStreamWriter2) getFactory(true, true)
-                .createXMLStreamWriter(bos, enc);
-            try {
-                sw.writeDTD(rootName, null, null, null);
-                sw.flush();
-                fail("Expected failure for root name not representable in "+enc
-                     +"; instead got output '"+new String(bos.toByteArray(), "ISO-8859-1")+"'");
-            } catch (XMLStreamException sex) {
-                verifyException(sex, "Invalid XML character");
+        for (boolean validateNames : new boolean[] { false, true }) {
+            for (String enc : new String[] { "US-ASCII", "ISO-8859-1" }) {
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                XMLStreamWriter2 sw = (XMLStreamWriter2) getFactory(validateNames, true)
+                    .createXMLStreamWriter(bos, enc);
+                try {
+                    sw.writeDTD(rootName, null, null, null);
+                    sw.flush();
+                    fail("Expected failure for root name not representable in "+enc
+                         +" (validate-names "+validateNames+"); instead got output '"
+                         +new String(bos.toByteArray(), "ISO-8859-1")+"'");
+                } catch (XMLStreamException sex) {
+                    verifyException(sex, "Invalid XML character");
+                }
             }
         }
     }
@@ -452,14 +459,18 @@ public class TestNameValidation
         throws Exception
     {
         final String rootName = "ré";
-        ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        XMLStreamWriter2 sw = (XMLStreamWriter2) getFactory(true, true)
-            .createXMLStreamWriter(bos, "ISO-8859-1");
-        sw.writeDTD(rootName, null, null, null);
-        sw.writeEmptyElement(rootName);
-        sw.close();
-        assertEquals("<!DOCTYPE "+rootName+"><"+rootName+"/>",
-                     new String(bos.toByteArray(), "ISO-8859-1"));
+
+        for (boolean validateNames : new boolean[] { false, true }) {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            XMLStreamWriter2 sw = (XMLStreamWriter2) getFactory(validateNames, true)
+                .createXMLStreamWriter(bos, "ISO-8859-1");
+            sw.writeDTD(rootName, null, null, null);
+            sw.writeEmptyElement(rootName);
+            sw.close();
+            assertEquals("validate-names "+validateNames,
+                         "<!DOCTYPE "+rootName+"><"+rootName+"/>",
+                         new String(bos.toByteArray(), "ISO-8859-1"));
+        }
     }
 
     /**


### PR DESCRIPTION
Byte-backed writers, DOCTYPE root name `rľļ` (U+013E and U+013C, both legal XML 1.0 name characters):

    US-ASCII   : <!DOCTYPE r><>
    ISO-8859-1 : <!DOCTYPE r><>

Found while diffing the DOCTYPE path of the two writer families. `BufferingXmlWriter.writeDTD()` checks the root name and writes it through the encoder. `EncodingXmlWriter.writeDTD()` hands it to `writeAscii()`, which narrows every char to its low byte, so 0x13E arrives as `>` and 0x13C as `<`. The injected markup closes the DOCTYPE early and the rest of the document follows it.

The name survives a parse, so it reaches the writer from a document: `copyEventFromReader` passes `DTDInfo.getDTDRootName()` straight into this method. Transcoding an untrusted document to US-ASCII or ISO-8859-1 is enough.

Every other name in these writers goes through `writeName()`/`writeRaw()`, which reports a character the encoding cannot represent. The root name now behaves the same way, with the `mCheckNames` guard `BufferingXmlWriter` already applies. Names the encoding covers are byte-for-byte unchanged.

`version` and `standalone` are the only other non-literal `writeAscii()` arguments left; both are constrained upstream in `BaseStreamWriter` and cannot carry a non-ASCII char, so I left them alone.
