### PR TITLE
Disable external entity resolution in MSV schema factories

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -201,6 +201,8 @@ Aizal Khan (@aizu-m)
  (7.2.2)
 * Contributed #318: Encode DOCTYPE root name in `EncodingXmlWriter.writeDTD()`
  (7.2.2)
+* Contributed #320: Disable external entity resolution in MSV schema factories
+ (7.2.2)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -202,7 +202,7 @@ Aizal Khan (@aizu-m)
 * Contributed #318: Encode DOCTYPE root name in `EncodingXmlWriter.writeDTD()`
  (7.2.2)
 * Contributed #320: Disable external entity resolution in MSV schema factories
- (7.2.2)
+ (7.3.0)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -27,6 +27,8 @@ Project: woodstox
  (contributed by @aizu-m)
 #318: Encode DOCTYPE root name in `EncodingXmlWriter.writeDTD()`
  (contributed by @aizu-m)
+#320: Disable external entity resolution in MSV schema factories
+ (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -4,6 +4,11 @@ Project: woodstox
 === Releases ===
 ------------------------------------------------------------------------
 
+7.3.0 (not yet released)
+
+#320: Disable external entity resolution in MSV schema factories
+ (contributed by @aizu-m)
+
 7.2.2 (not yet released)
 
 #300: Combine surrogate pairs in `BufferingXmlWriter` entity escaping
@@ -26,8 +31,6 @@ Project: woodstox
    a second time, when a replacing `InvalidCharHandler` is configured)
  (contributed by @aizu-m)
 #318: Encode DOCTYPE root name in `EncodingXmlWriter.writeDTD()`
- (contributed by @aizu-m)
-#320: Disable external entity resolution in MSV schema factories
  (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)

--- a/src/main/java/com/ctc/wstx/msv/BaseSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/msv/BaseSchemaFactory.java
@@ -167,10 +167,8 @@ public abstract class BaseSchemaFactory
      * Does not affect {@code xs:include} / {@code xs:import} or RELAX NG
      * {@code externalRef}: those are resolved by MSV itself, not through
      * entity resolution.
-     *
-     * @since 7.2.2
      */
-    protected static void disableExternalEntities(SAXParserFactory f)
+    static void disableExternalEntities(SAXParserFactory f)
     {
         setFeature(f, XMLConstants.FEATURE_SECURE_PROCESSING, true);
         setFeature(f, "http://xml.org/sax/features/external-general-entities", false);

--- a/src/main/java/com/ctc/wstx/msv/BaseSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/msv/BaseSchemaFactory.java
@@ -18,11 +18,15 @@ package com.ctc.wstx.msv;
 import java.io.*;
 import java.net.URL;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.stream.*;
 
 import org.xml.sax.InputSource;
 import org.xml.sax.Locator;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 import org.codehaus.stax2.validation.*;
 
 import com.ctc.wstx.api.ValidatorConfig;
@@ -150,8 +154,36 @@ public abstract class BaseSchemaFactory
         if (sSaxFactory == null) {
             sSaxFactory = SAXParserFactory.newInstance();
             sSaxFactory.setNamespaceAware(true); 
+            disableExternalEntities(sSaxFactory);
         }
         return sSaxFactory;
+    }
+
+    /**
+     * Method for disabling resolution of external entities referenced from
+     * schema documents. Neither this factory nor MSV exposes the underlying
+     * SAX parser, so callers have no way of doing this themselves.
+     *<p>
+     * Does not affect {@code xs:include} / {@code xs:import} or RELAX NG
+     * {@code externalRef}: those are resolved by MSV itself, not through
+     * entity resolution.
+     *
+     * @since 7.2.2
+     */
+    protected static void disableExternalEntities(SAXParserFactory f)
+    {
+        setFeature(f, XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        setFeature(f, "http://xml.org/sax/features/external-general-entities", false);
+        setFeature(f, "http://xml.org/sax/features/external-parameter-entities", false);
+    }
+
+    private static void setFeature(SAXParserFactory f, String feature, boolean state)
+    {
+        try {
+            f.setFeature(feature, state);
+        } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+            // Not every SAX implementation knows every feature; nothing to do
+        }
     }
 
     /*

--- a/src/main/java/com/ctc/wstx/msv/W3CMultiSchemaFactory.java
+++ b/src/main/java/com/ctc/wstx/msv/W3CMultiSchemaFactory.java
@@ -70,6 +70,7 @@ public class W3CMultiSchemaFactory
     public W3CMultiSchemaFactory() {
         parserFactory = SAXParserFactory.newInstance();
         parserFactory.setNamespaceAware(true); 
+        BaseSchemaFactory.disableExternalEntities(parserFactory);
     }
 
     static class RecursiveAllowedXMLSchemaReader extends XMLSchemaReader {

--- a/src/test/java/wstxtest/vstream/TestSchemaExternalEntity.java
+++ b/src/test/java/wstxtest/vstream/TestSchemaExternalEntity.java
@@ -1,0 +1,146 @@
+package wstxtest.vstream;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringReader;
+import java.io.Writer;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.codehaus.stax2.XMLStreamReader2;
+import org.codehaus.stax2.validation.XMLValidationException;
+import org.codehaus.stax2.validation.XMLValidationSchema;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests to verify that entities referring to external resources are not
+ * resolved while reading schema documents.
+ */
+public class TestSchemaExternalEntity
+    extends BaseValidationTest
+{
+    /**
+     * External parameter entity: declarations it contains must not be
+     * pulled into the schema.
+     */
+    @Test
+    public void testW3CSchemaExternalParameterEntity() throws Exception
+    {
+        File dtd = writeTempFile("wstx-ext", ".dtd",
+                "<!ENTITY injected \"viaExternalEntity\">");
+        String schema =
+            "<?xml version='1.0'?>\n"
+            +"<!DOCTYPE xs:schema [\n"
+            +"  <!ENTITY % ext SYSTEM '"+dtd.toURI()+"'>\n"
+            +"  %ext;\n"
+            +"]>\n"
+            +"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>\n"
+            +"  <xs:element name='&injected;' type='xs:string'/>\n"
+            +"</xs:schema>";
+        try {
+            parseW3CSchema(schema);
+            fail("Expected failure for schema using an external parameter entity");
+        } catch (XMLStreamException e) {
+            verifyException(e, "was referenced, but not declared");
+        }
+    }
+
+    /**
+     * Same for the external subset of the schema's own DOCTYPE declaration.
+     */
+    @Test
+    public void testW3CSchemaExternalSubset() throws Exception
+    {
+        File dtd = writeTempFile("wstx-ext", ".dtd",
+                "<!ENTITY injected \"viaExternalSubset\">");
+        String schema =
+            "<?xml version='1.0'?>\n"
+            +"<!DOCTYPE xs:schema SYSTEM '"+dtd.toURI()+"'>\n"
+            +"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>\n"
+            +"  <xs:element name='&injected;' type='xs:string'/>\n"
+            +"</xs:schema>";
+        try {
+            parseW3CSchema(schema);
+            fail("Expected failure for schema using an external DTD subset");
+        } catch (XMLStreamException e) {
+            verifyException(e, "accessExternalDTD");
+        }
+    }
+
+    /**
+     * External general entity: contents of the referenced file must not end
+     * up in the grammar.
+     */
+    @Test
+    public void testRelaxNGExternalEntity() throws Exception
+    {
+        final String SECRET = "contentsOfLocalFile";
+        File secret = writeTempFile("wstx-secret", ".txt", SECRET);
+        String schema =
+            "<?xml version='1.0'?>\n"
+            +"<!DOCTYPE element [\n"
+            +"  <!ENTITY xxe SYSTEM '"+secret.toURI()+"'>\n"
+            +"]>\n"
+            +"<element name='root' xmlns='http://relaxng.org/ns/structure/1.0'>\n"
+            +"  <value>&xxe;</value>\n"
+            +"</element>";
+        XMLValidationSchema sch = parseRngSchema(schema);
+        assertFalse("File contents must not be readable through an external entity",
+                validates("<root>"+SECRET+"</root>", sch));
+    }
+
+    /**
+     * Entities declared in the internal subset are unaffected, as are
+     * schemas that declare no DOCTYPE at all.
+     */
+    @Test
+    public void testW3CSchemaInternalEntity() throws Exception
+    {
+        String schema =
+            "<?xml version='1.0'?>\n"
+            +"<!DOCTYPE xs:schema [ <!ENTITY local 'declaredLocally'> ]>\n"
+            +"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>\n"
+            +"  <xs:element name='&local;' type='xs:string'/>\n"
+            +"</xs:schema>";
+        XMLValidationSchema sch = parseW3CSchema(schema);
+        assertTrue("Internal entity should still be expanded",
+                validates("<declaredLocally>x</declaredLocally>", sch));
+    }
+
+    /*
+    ///////////////////////////////////////////////////////////////////////
+    // Helper methods
+    ///////////////////////////////////////////////////////////////////////
+     */
+
+    private boolean validates(String doc, XMLValidationSchema schema) throws XMLStreamException
+    {
+        XMLStreamReader2 sr = (XMLStreamReader2) getInputFactory().createXMLStreamReader(new StringReader(doc));
+        try {
+            sr.validateAgainst(schema);
+            while (sr.hasNext()) {
+                sr.next();
+            }
+            return true;
+        } catch (XMLValidationException e) {
+            return false;
+        } finally {
+            sr.close();
+        }
+    }
+
+    private File writeTempFile(String prefix, String suffix, String contents) throws Exception
+    {
+        File f = File.createTempFile(prefix, suffix);
+        f.deleteOnExit();
+        Writer w = new OutputStreamWriter(new FileOutputStream(f), "UTF-8");
+        try {
+            w.write(contents);
+        } finally {
+            w.close();
+        }
+        return f;
+    }
+}

--- a/src/test/java/wstxtest/vstream/TestSchemaExternalEntity.java
+++ b/src/test/java/wstxtest/vstream/TestSchemaExternalEntity.java
@@ -5,22 +5,41 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.xml.stream.XMLStreamException;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
 
 import org.codehaus.stax2.XMLStreamReader2;
 import org.codehaus.stax2.validation.XMLValidationException;
 import org.codehaus.stax2.validation.XMLValidationSchema;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.ctc.wstx.msv.W3CMultiSchemaFactory;
 
 /**
  * Tests to verify that entities referring to external resources are not
- * resolved while reading schema documents.
+ * resolved while reading schema documents; and, conversely, that schema
+ * composition ({@code xs:include}, {@code xs:import}, RELAX NG
+ * {@code externalRef}) -- which MSV resolves itself, not via entity
+ * resolution -- keeps working.
  */
 public class TestSchemaExternalEntity
     extends BaseValidationTest
 {
+    @TempDir
+    File tempDir;
+
+    /*
+    ///////////////////////////////////////////////////////////////////////
+    // External entities: must not be resolved
+    ///////////////////////////////////////////////////////////////////////
+     */
+
     /**
      * External parameter entity: declarations it contains must not be
      * pulled into the schema.
@@ -28,22 +47,12 @@ public class TestSchemaExternalEntity
     @Test
     public void testW3CSchemaExternalParameterEntity() throws Exception
     {
-        File dtd = writeTempFile("wstx-ext", ".dtd",
-                "<!ENTITY injected \"viaExternalEntity\">");
-        String schema =
-            "<?xml version='1.0'?>\n"
-            +"<!DOCTYPE xs:schema [\n"
-            +"  <!ENTITY % ext SYSTEM '"+dtd.toURI()+"'>\n"
-            +"  %ext;\n"
-            +"]>\n"
-            +"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>\n"
-            +"  <xs:element name='&injected;' type='xs:string'/>\n"
-            +"</xs:schema>";
         try {
-            parseW3CSchema(schema);
+            parseW3CSchema(schemaWithExternalParameterEntity());
             fail("Expected failure for schema using an external parameter entity");
         } catch (XMLStreamException e) {
-            verifyException(e, "was referenced, but not declared");
+            // Exact wording is parser-specific; entity name is not
+            verifyException(e, "injected");
         }
     }
 
@@ -53,8 +62,7 @@ public class TestSchemaExternalEntity
     @Test
     public void testW3CSchemaExternalSubset() throws Exception
     {
-        File dtd = writeTempFile("wstx-ext", ".dtd",
-                "<!ENTITY injected \"viaExternalSubset\">");
+        File dtd = writeFile("ext.dtd", "<!ENTITY injected \"viaExternalSubset\">");
         String schema =
             "<?xml version='1.0'?>\n"
             +"<!DOCTYPE xs:schema SYSTEM '"+dtd.toURI()+"'>\n"
@@ -70,6 +78,24 @@ public class TestSchemaExternalEntity
     }
 
     /**
+     * Same for schemas read through {@link W3CMultiSchemaFactory}, which
+     * uses a SAX parser factory of its own.
+     */
+    @Test
+    public void testW3CMultiSchemaExternalParameterEntity() throws Exception
+    {
+        File xsd = writeFile("multi.xsd", schemaWithExternalParameterEntity());
+        Map<String,Source> sources = new HashMap<String,Source>();
+        sources.put("", new StreamSource(xsd.toURI().toString()));
+        try {
+            new W3CMultiSchemaFactory().createSchema(tempDir.toURI().toString(), sources);
+            fail("Expected failure for schema using an external parameter entity");
+        } catch (XMLStreamException e) {
+            verifyException(e, "Failed to load schemas");
+        }
+    }
+
+    /**
      * External general entity: contents of the referenced file must not end
      * up in the grammar.
      */
@@ -77,7 +103,7 @@ public class TestSchemaExternalEntity
     public void testRelaxNGExternalEntity() throws Exception
     {
         final String SECRET = "contentsOfLocalFile";
-        File secret = writeTempFile("wstx-secret", ".txt", SECRET);
+        File secret = writeFile("secret.txt", SECRET);
         String schema =
             "<?xml version='1.0'?>\n"
             +"<!DOCTYPE element [\n"
@@ -92,8 +118,7 @@ public class TestSchemaExternalEntity
     }
 
     /**
-     * Entities declared in the internal subset are unaffected, as are
-     * schemas that declare no DOCTYPE at all.
+     * Entities declared in the internal subset are unaffected.
      */
     @Test
     public void testW3CSchemaInternalEntity() throws Exception
@@ -111,9 +136,80 @@ public class TestSchemaExternalEntity
 
     /*
     ///////////////////////////////////////////////////////////////////////
+    // Schema composition: must keep working
+    ///////////////////////////////////////////////////////////////////////
+     */
+
+    @Test
+    public void testW3CSchemaInclude() throws Exception
+    {
+        writeFile("included.xsd",
+                "<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>\n"
+                +"  <xs:element name='root' type='xs:string'/>\n"
+                +"</xs:schema>");
+        File main = writeFile("including.xsd",
+                "<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>\n"
+                +"  <xs:include schemaLocation='included.xsd'/>\n"
+                +"</xs:schema>");
+        XMLValidationSchema sch = parseSchema(main.toURI().toURL(),
+                XMLValidationSchema.SCHEMA_ID_W3C_SCHEMA);
+        assertTrue("'xs:include' should still be resolved",
+                validates("<root>x</root>", sch));
+    }
+
+    @Test
+    public void testW3CSchemaImport() throws Exception
+    {
+        writeFile("imported.xsd",
+                "<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' targetNamespace='urn:sub'>\n"
+                +"  <xs:element name='child' type='xs:string'/>\n"
+                +"</xs:schema>");
+        File main = writeFile("importing.xsd",
+                "<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:s='urn:sub'>\n"
+                +"  <xs:import namespace='urn:sub' schemaLocation='imported.xsd'/>\n"
+                +"  <xs:element name='root'>\n"
+                +"    <xs:complexType><xs:sequence><xs:element ref='s:child'/></xs:sequence></xs:complexType>\n"
+                +"  </xs:element>\n"
+                +"</xs:schema>");
+        XMLValidationSchema sch = parseSchema(main.toURI().toURL(),
+                XMLValidationSchema.SCHEMA_ID_W3C_SCHEMA);
+        assertTrue("'xs:import' should still be resolved",
+                validates("<root><child xmlns='urn:sub'>x</child></root>", sch));
+    }
+
+    @Test
+    public void testRelaxNGExternalRef() throws Exception
+    {
+        writeFile("referenced.rng",
+                "<element name='root' xmlns='http://relaxng.org/ns/structure/1.0'><text/></element>");
+        File main = writeFile("referring.rng",
+                "<grammar xmlns='http://relaxng.org/ns/structure/1.0'>\n"
+                +"  <start><externalRef href='referenced.rng'/></start>\n"
+                +"</grammar>");
+        XMLValidationSchema sch = parseSchema(main.toURI().toURL(),
+                XMLValidationSchema.SCHEMA_ID_RELAXNG);
+        assertTrue("'externalRef' should still be resolved",
+                validates("<root>x</root>", sch));
+    }
+
+    /*
+    ///////////////////////////////////////////////////////////////////////
     // Helper methods
     ///////////////////////////////////////////////////////////////////////
      */
+
+    private String schemaWithExternalParameterEntity() throws Exception
+    {
+        File dtd = writeFile("ext.dtd", "<!ENTITY injected \"viaExternalEntity\">");
+        return "<?xml version='1.0'?>\n"
+            +"<!DOCTYPE xs:schema [\n"
+            +"  <!ENTITY % ext SYSTEM '"+dtd.toURI()+"'>\n"
+            +"  %ext;\n"
+            +"]>\n"
+            +"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>\n"
+            +"  <xs:element name='&injected;' type='xs:string'/>\n"
+            +"</xs:schema>";
+    }
 
     private boolean validates(String doc, XMLValidationSchema schema) throws XMLStreamException
     {
@@ -131,10 +227,9 @@ public class TestSchemaExternalEntity
         }
     }
 
-    private File writeTempFile(String prefix, String suffix, String contents) throws Exception
+    private File writeFile(String name, String contents) throws Exception
     {
-        File f = File.createTempFile(prefix, suffix);
-        f.deleteOnExit();
+        File f = new File(tempDir, name);
         Writer w = new OutputStreamWriter(new FileOutputStream(f), "UTF-8");
         try {
             w.write(contents);


### PR DESCRIPTION
Reproducer output against `main`, schema documents carrying external entities:

    W3C  : validates <InjectedByExternalEntity/> ? true       <!ENTITY % ext SYSTEM 'file:...'>  %ext;
    RNG  : validates <root>LeakedFromLocalFile</root> ? true  <!ENTITY xxe SYSTEM 'file:...'>  <value>&xxe;</value>

Noticed while grepping the tree for `SAXParserFactory.newInstance()`. Both MSV construction sites apply only `setNamespaceAware(true)`, so entities in a schema document get resolved: `BaseSchemaFactory.getSaxFactory()`, shared by the W3C and RELAX NG factories, and the `W3CMultiSchemaFactory` constructor. The RELAX NG case copies the referenced file into the grammar verbatim. The W3C case pulls declarations out of a fetched DTD and applies them.

Neither the Stax2 factory API nor MSV hands the SAX parser back, so a caller has no way to switch this off. That is why the fix sits at the two construction sites.

`xs:include` / `xs:import` and `externalRef` are resolved by MSV itself rather than through entity resolution, so those keep working. Entities declared in an internal subset, and schemas with no DOCTYPE at all, behave as before. Test covers both directions.
