### PR TITLE
Honour `external-parameter-entities` feature in SAX layer

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -201,6 +201,8 @@ Aizal Khan (@aizu-m)
  (7.2.2)
 * Contributed #318: Encode DOCTYPE root name in `EncodingXmlWriter.writeDTD()`
  (7.2.2)
+* Contributed #321: Honour `external-parameter-entities` feature in SAX layer
+ (7.2.2)
 
 Skrethel (@Skrethel)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -27,6 +27,8 @@ Project: woodstox
  (contributed by @aizu-m)
 #318: Encode DOCTYPE root name in `EncodingXmlWriter.writeDTD()`
  (contributed by @aizu-m)
+#321: Honour `external-parameter-entities` feature in SAX layer
+ (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)
 

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -28,6 +28,10 @@ Project: woodstox
 #318: Encode DOCTYPE root name in `EncodingXmlWriter.writeDTD()`
  (contributed by @aizu-m)
 #321: Honour `external-parameter-entities` feature in SAX layer
+  (note: maps onto the same single setting as `external-general-entities`,
+   so setting either feature also changes the other)
+  (also recognize `FEATURE_SECURE_PROCESSING` in `WstxSAXParser`, not just
+   in `WstxSAXParserFactory`)
  (contributed by @aizu-m)
 
 7.2.1 (07-Jun-2026)

--- a/src/main/java/com/ctc/wstx/sax/WstxSAXParser.java
+++ b/src/main/java/com/ctc/wstx/sax/WstxSAXParser.java
@@ -123,6 +123,15 @@ import com.ctc.wstx.util.URLUtil;
  * This class implements parser part of JAXP and SAX interfaces; and
  * effectively offers an alternative to using Stax input factory /
  * stream reader combination.
+ *<p>
+ * NOTE: Woodstox has a single setting for external entity support
+ * ({@code XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES}), so the SAX
+ * features {@code external-general-entities} and
+ * {@code external-parameter-entities} are <b>not independent</b>: setting
+ * either one also changes the other, and {@link #getFeature} reports the
+ * same value for both. In particular, enabling one will re-enable the other
+ * if it had been disabled, so callers that want external entities disabled
+ * should not set either feature to {@code true} afterwards.
  */
 @SuppressWarnings("deprecation")
 public class WstxSAXParser

--- a/src/main/java/com/ctc/wstx/sax/WstxSAXParser.java
+++ b/src/main/java/com/ctc/wstx/sax/WstxSAXParser.java
@@ -459,6 +459,8 @@ public class WstxSAXParser
             return true;
         } else if (stdFeat == SAXFeature.XML_1_1) {
             return true;
+        } else if (stdFeat == SAXFeature.JDK_SECURE_PROCESSING) {
+            return mConfig.willProcessSecurely();
         }
 
         throw new SAXNotRecognizedException("Feature '"+name+"' not recognized");
@@ -504,7 +506,9 @@ public class WstxSAXParser
         if (stdFeat == SAXFeature.EXTERNAL_GENERAL_ENTITIES) {
             mConfig.doSupportExternalEntities(value);
         } else if (stdFeat == SAXFeature.EXTERNAL_PARAMETER_ENTITIES) {
-            // !!! TODO
+            // Woodstox has a single setting for external entities, covering both
+            // general and parameter entities; getFeature() already reports it for both
+            mConfig.doSupportExternalEntities(value);
         } else if (stdFeat == SAXFeature.IS_STANDALONE) {
             readOnly = true;
         } else if (stdFeat == SAXFeature.LEXICAL_HANDLER_PARAMETER_ENTITIES) {
@@ -531,6 +535,8 @@ public class WstxSAXParser
             invalidValue = !value;
         } else if (stdFeat == SAXFeature.XML_1_1) {
             readOnly = true;
+        } else if (stdFeat == SAXFeature.JDK_SECURE_PROCESSING) {
+            mConfig.doProcessSecurely(value);
         } else {
             throw new SAXNotRecognizedException("Feature '"+name+"' not recognized");
         }

--- a/src/main/java/com/ctc/wstx/sax/WstxSAXParserFactory.java
+++ b/src/main/java/com/ctc/wstx/sax/WstxSAXParserFactory.java
@@ -30,6 +30,15 @@ import com.ctc.wstx.stax.WstxInputFactory;
  * However, effort is made to recognize all existing standard features
  * and properties, to allow using code to figure out existing
  * capabilities automatically.
+ *<p>
+ * NOTE: Woodstox has a single setting for external entity support
+ * ({@code XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES}), so the SAX
+ * features {@code external-general-entities} and
+ * {@code external-parameter-entities} are <b>not independent</b>: setting
+ * either one also changes the other, and {@link #getFeature} reports the
+ * same value for both. In particular, enabling one will re-enable the other
+ * if it had been disabled, so callers that want external entities disabled
+ * should not set either feature to {@code true} afterwards.
  */
 public class WstxSAXParserFactory
     extends SAXParserFactory

--- a/src/main/java/com/ctc/wstx/sax/WstxSAXParserFactory.java
+++ b/src/main/java/com/ctc/wstx/sax/WstxSAXParserFactory.java
@@ -133,7 +133,9 @@ public class WstxSAXParserFactory
         if (stdFeat == SAXFeature.EXTERNAL_GENERAL_ENTITIES) {
             mStaxFactory.getConfig().doSupportExternalEntities(value);
         } else if (stdFeat == SAXFeature.EXTERNAL_PARAMETER_ENTITIES) {
-            // !!! TODO
+            // Woodstox has a single setting for external entities, covering both
+            // general and parameter entities; getFeature() already reports it for both
+            mStaxFactory.getConfig().doSupportExternalEntities(value);
         } else if (stdFeat == SAXFeature.IS_STANDALONE) {
             readOnly = true;
         } else if (stdFeat == SAXFeature.LEXICAL_HANDLER_PARAMETER_ENTITIES) {

--- a/src/test/java/wstxtest/sax/TestSaxProperties.java
+++ b/src/test/java/wstxtest/sax/TestSaxProperties.java
@@ -6,6 +6,7 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.SAXParser;
 
 import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
 
 import com.ctc.wstx.sax.WstxSAXParserFactory;
 
@@ -15,6 +16,16 @@ import org.junit.jupiter.api.Test;
 
 public class TestSaxProperties extends BaseWstxTest
 {
+    private final static String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+
+    private final static String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+
+    // Document that refers to an external parameter entity from the internal
+    // DTD subset; system id points to a file that does not exist, so an attempt
+    // to actually resolve it fails with a distinctive error
+    private final static String DOC_WITH_EXTERNAL_PE =
+        "<!DOCTYPE root [ <!ENTITY % pe SYSTEM \"file:///no-such-file-woodstox-test.dtd\"> %pe; ]><root />";
+
     // [woodstox-core#77]: Don't barf on "secure processing" setting
     @Test
     public void testSecureProcessingFactory() throws Exception
@@ -50,5 +61,59 @@ public class TestSaxProperties extends BaseWstxTest
         MyHandler h = new MyHandler();
         InputSource src = new InputSource(new StringReader("<root></root>"));
         sp.parse(src, h);
+    }
+
+    // Same feature is settable via the XMLReader the parser exposes
+    @Test
+    public void testSecureProcessingXmlReader() throws Exception
+    {
+        XMLReader r = new WstxSAXParserFactory().newSAXParser().getXMLReader();
+
+        assertFalse(r.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+        r.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        assertTrue(r.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+        r.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, false);
+        assertFalse(r.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
+    }
+
+    @Test
+    public void testExternalParameterEntitiesFactory() throws Exception
+    {
+        WstxSAXParserFactory f = new WstxSAXParserFactory();
+
+        // enabled by default, like external general entities
+        assertTrue(f.getFeature(EXTERNAL_PARAMETER_ENTITIES));
+
+        f.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+        assertFalse(f.getFeature(EXTERNAL_PARAMETER_ENTITIES));
+        assertFalse(f.getFeature(EXTERNAL_GENERAL_ENTITIES));
+
+        try {
+            f.newSAXParser().parse(new InputSource(new StringReader(DOC_WITH_EXTERNAL_PE)),
+                    new MyHandler());
+            fail("Should not resolve external parameter entity");
+        } catch (Exception e) {
+            verifyException(e, "isSupportingExternalEntities");
+        }
+    }
+
+    @Test
+    public void testExternalParameterEntitiesXmlReader() throws Exception
+    {
+        XMLReader r = new WstxSAXParserFactory().newSAXParser().getXMLReader();
+
+        assertTrue(r.getFeature(EXTERNAL_PARAMETER_ENTITIES));
+
+        r.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+        assertFalse(r.getFeature(EXTERNAL_PARAMETER_ENTITIES));
+        assertFalse(r.getFeature(EXTERNAL_GENERAL_ENTITIES));
+
+        r.setContentHandler(new MyHandler());
+        try {
+            r.parse(new InputSource(new StringReader(DOC_WITH_EXTERNAL_PE)));
+            fail("Should not resolve external parameter entity");
+        } catch (Exception e) {
+            verifyException(e, "isSupportingExternalEntities");
+        }
     }
 }

--- a/src/test/java/wstxtest/sax/TestSaxProperties.java
+++ b/src/test/java/wstxtest/sax/TestSaxProperties.java
@@ -6,6 +6,7 @@ import javax.xml.XMLConstants;
 import javax.xml.parsers.SAXParser;
 
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 
 import com.ctc.wstx.sax.WstxSAXParserFactory;
@@ -20,11 +21,23 @@ public class TestSaxProperties extends BaseWstxTest
 
     private final static String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
 
-    // Document that refers to an external parameter entity from the internal
-    // DTD subset; system id points to a file that does not exist, so an attempt
-    // to actually resolve it fails with a distinctive error
-    private final static String DOC_WITH_EXTERNAL_PE =
-        "<!DOCTYPE root [ <!ENTITY % pe SYSTEM \"file:///no-such-file-woodstox-test.dtd\"> %pe; ]><root />";
+    /**
+     * Document that pulls in an external parameter entity from the internal DTD
+     * subset. The referenced file really does exist and declares a defaulted
+     * attribute, so that:
+     *<ul>
+     * <li>a successful parse is observable ({@code MyHandler._attrs} becomes 1
+     *   only if the external subset was actually read), and
+     *  </li>
+     * <li>a failed parse can only be due to the feature being disabled, not due
+     *   to the system id being unresolvable
+     *  </li>
+     *</ul>
+     */
+    private static String docWithExternalPE() {
+        String systemId = TestSaxProperties.class.getResource("external-pe.dtd").toString();
+        return "<!DOCTYPE root [ <!ENTITY % pe SYSTEM \""+systemId+"\"> %pe; ]><root />";
+    }
 
     // [woodstox-core#77]: Don't barf on "secure processing" setting
     @Test
@@ -76,6 +89,27 @@ public class TestSaxProperties extends BaseWstxTest
         assertFalse(r.getFeature(XMLConstants.FEATURE_SECURE_PROCESSING));
     }
 
+    // Positive control for the two tests below: with the feature left at its
+    // default, the external parameter entity really is resolved and the
+    // declarations it contains take effect
+    @Test
+    public void testExternalParameterEntitiesEnabled() throws Exception
+    {
+        WstxSAXParserFactory f = new WstxSAXParserFactory();
+
+        // enabled by default, like external general entities
+        assertTrue(f.getFeature(EXTERNAL_PARAMETER_ENTITIES));
+        assertTrue(f.getFeature(EXTERNAL_GENERAL_ENTITIES));
+
+        MyHandler h = new MyHandler();
+        f.newSAXParser().parse(new InputSource(new StringReader(docWithExternalPE())), h);
+
+        assertEquals("Should have parsed the root element", 1, h._elems);
+        // and the defaulted attribute only exists if the external subset was read
+        assertEquals("Should have defaulted attribute from external parameter entity",
+                1, h._attrs);
+    }
+
     @Test
     public void testExternalParameterEntitiesFactory() throws Exception
     {
@@ -89,10 +123,10 @@ public class TestSaxProperties extends BaseWstxTest
         assertFalse(f.getFeature(EXTERNAL_GENERAL_ENTITIES));
 
         try {
-            f.newSAXParser().parse(new InputSource(new StringReader(DOC_WITH_EXTERNAL_PE)),
+            f.newSAXParser().parse(new InputSource(new StringReader(docWithExternalPE())),
                     new MyHandler());
             fail("Should not resolve external parameter entity");
-        } catch (Exception e) {
+        } catch (SAXException e) {
             verifyException(e, "isSupportingExternalEntities");
         }
     }
@@ -110,9 +144,9 @@ public class TestSaxProperties extends BaseWstxTest
 
         r.setContentHandler(new MyHandler());
         try {
-            r.parse(new InputSource(new StringReader(DOC_WITH_EXTERNAL_PE)));
+            r.parse(new InputSource(new StringReader(docWithExternalPE())));
             fail("Should not resolve external parameter entity");
-        } catch (Exception e) {
+        } catch (SAXException e) {
             verifyException(e, "isSupportingExternalEntities");
         }
     }

--- a/src/test/resources/wstxtest/sax/external-pe.dtd
+++ b/src/test/resources/wstxtest/sax/external-pe.dtd
@@ -1,0 +1,2 @@
+<!ELEMENT root EMPTY>
+<!ATTLIST root extpe CDATA "from-external-pe">


### PR DESCRIPTION
Went looking at what the SAX layer actually does with the usual XXE hardening calls.

1. `setFeature("http://xml.org/sax/features/external-parameter-entities", false)` was a no-op in both `WstxSAXParserFactory` and `WstxSAXParser`. Nothing thrown, and `getFeature()` still answered `true`. An internal-subset `<!ENTITY % pe SYSTEM "file:///...">` was still resolved. I pointed the system id at a missing path and got `FileNotFoundException` back, so the read really was attempted. Disabling `external-general-entities` does stop the same document, so the single `willSupportExternalEntities()` flag already covers parameter entities and only the setter was unwired. `getFeature()` maps both features onto that flag, so the setter now does the same.

2. `FEATURE_SECURE_PROCESSING` was recognised on the factory but not on the parser, so `newSAXParser().getXMLReader().setFeature(...)` threw `SAXNotRecognizedException`. That is the failure #77 hit against the factory, before #61 wired it up on that side only.

Regression tests in `TestSaxProperties`, at both factory and `XMLReader` level.
